### PR TITLE
feat: v0.4.3 — regen-sdk-app 스킬 추가 (UPDATE_SDK_APP)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ The end-to-end workflow for building a SeamOS app with this plugin:
 | Phase | Layer | Actions |
 |-------|-------|---------|
 | 1. Project Creation | FD MCP (planned) / create-project skill (implemented) | Browse interfaces (offlineDB) → synthesize interface JSON → generate FSP **+ SDK/APP skeleton** via Dockerized FD Headless (`--skip-sdk-app` for FSP-only) |
+| 1b. SDK/APP Refresh | regen-sdk-app skill | Re-run FD Headless `UPDATE_SDK_APP` after the FSP changes — merges regenerated SDK hooks into the existing app project while preserving user code |
 | 2. Business Logic | SeamOS Skills | Data handling, WebSocket, REST API, verification |
 | 3. UI Development | SeamOS Skills | UI framework template, build & integration |
 | 4. Testing | FD MCP | Build, simulation, run |

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 **Claude Code plugin for the SeamOS AI Native developer ecosystem**
 
-[![Version](https://img.shields.io/badge/version-0.4.2-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
-[![Skills](https://img.shields.io/badge/skills-6-orange.svg)](#skills)
+[![Version](https://img.shields.io/badge/version-0.4.3-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
+[![Skills](https://img.shields.io/badge/skills-7-orange.svg)](#skills)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 [![Org](https://img.shields.io/badge/org-AGMO--Inc-green.svg)](https://github.com/AGMO-Inc)
 
@@ -244,11 +244,33 @@ Create a new SeamOS project (FSP + SDK/APP skeleton) via a Dockerized FD Headles
 
 ---
 
+### regen-sdk-app
+
+Re-run FD Headless `UPDATE_SDK_APP` on an existing project. Refreshes the generated SDK hooks + skeleton wiring while preserving your hand-written app code. Reads project parameters from `.seamos-context.json` (written by `create-project`), so no flags are usually needed.
+
+**Triggers:** `SDK 재생성` · `APP 재생성` · `SDK 업데이트` · `skeleton 갱신` · `FSP 바뀌었는데 앱에 반영` · `regen sdk` · `UPDATE_SDK_APP`
+
+```
+/seamos-everywhere:regen-sdk-app
+```
+
+**Flow:**
+1. Finds `USER_ROOT` (directory containing `.mcp.json`) and reads `.seamos-context.json`
+2. Derives `PROJECT_NAME`, `APP_PROJECT_NAME`, `CODEGEN_TYPE`, `APP_PROJECT_PATH` from `last_project.*` (CLI flags override)
+3. Writes `_config.prop` with the extra `app.project.path=/workspace/...` line required by UPDATE_SDK_APP (PDF §4)
+4. Runs `seamos-fd-headless:0.4.2` with `FD_OPERATION=UPDATE_SDK_APP`
+5. Updates context with `operation=UPDATE_SDK_APP` + `sdk_app_updated_at` (preserves `sdk_app_completed_at`)
+
+> When the **interface** itself changed, run `create-project --force-clean` first (to regenerate the FSP from the updated interface), then `regen-sdk-app`. This skill alone won't pick up interface.json changes — it reads the FSP as-is.
+
+---
+
 ### Skill comparison
 
 | Want to... | Skill |
 |---|---|
 | Create a new SeamOS project (FSP + SDK/APP skeleton) | `create-project` |
+| Merge FSP changes into an existing app (preserve user code) | `regen-sdk-app` |
 | Generate REST, WebSocket, DB, or Lifecycle framework code | `seamos-app-framework` |
 | Look up plugin interfaces and generate signal code | `seamos-plugins` |
 | Build a `.fif` deployment package | `build-fif` |

--- a/skills/create-project/references/local-e2e-checklist.md
+++ b/skills/create-project/references/local-e2e-checklist.md
@@ -68,15 +68,21 @@ Tags: `[docs, test, requires-docker, manual]`. These steps require Docker and a 
 - [ ] **U6. Force-clean preserves SSOT and seamos-assets** — `bash <repo>/skills/create-project/scripts/create-project.sh --project-name MyE2E --force-clean --interface-json <...>`
   - Expected: workspace regenerated, `/tmp/seamos-e2e/seamos-assets/` intact, `/tmp/seamos-e2e/MyE2E-interface.json` SSOT still exists
 
+- [ ] **U7. regen-sdk-app refreshes skeleton** (after U2) — touch a file under `<workspace>/<PROJECT>/<PROJECT>_<APP>/src/...` to simulate user edits, then run `cd /tmp/seamos-e2e && bash <repo>/skills/regen-sdk-app/scripts/regen-sdk-app.sh`
+  - Expected: UPDATE_SDK_APP completes (`FD HEADLESS EXECUTION COMPLETED SUCCESSFULLY` in `run-sdk-app-update.log`), `.seamos-context.json .last_project.operation == "UPDATE_SDK_APP"`, `sdk_app_updated_at` populated, `sdk_app_completed_at` preserved from U2, user-added file still present
+
 ## FAST_CHECK (Docker-free smoke)
 
-Set `FAST_CHECK=1` to skip Docker-dependent steps (U2, U4, U6) and substitute the Docker-free smoke harness, which exercises the same path-resolution / context-handoff logic via `--dry-run`:
+Set `FAST_CHECK=1` to skip Docker-dependent steps (U2, U4, U6, U7) and substitute the Docker-free smoke harnesses:
 
 ```bash
 FAST_CHECK=1 bash <repo>/skills/create-project/evals/smoke.sh
+FAST_CHECK=1 bash <repo>/skills/regen-sdk-app/evals/smoke.sh
 ```
 
-The smoke script (v4 CIMP-4) verifies that `create-project.sh --dry-run` and `build-fif.sh --dry-run` emit the expected `USER_ROOT=`, `PROJECT_NAME=`, `WORKSPACE=`, `FSP_PATH=`, `BUILD_DIR=`, and `CONTEXT_FILE=` variables — without any docker invocation — and asserts each value matches the fixture.
+`create-project/evals/smoke.sh` (v4 CIMP-4) verifies create-project + build-fif dry-run emits `USER_ROOT=`, `PROJECT_NAME=`, `WORKSPACE=`, `FSP_PATH=`, `BUILD_DIR=`, `CONTEXT_FILE=`.
+
+`regen-sdk-app/evals/smoke.sh` verifies (A) missing-context errors with exit 64, (B) partial-context enumerates missing fields, (C) full-context dry-run emits all 10 path vars + `FD_OPERATION=UPDATE_SDK_APP`, (D) upward `.mcp.json` search resolves `USER_ROOT` from a nested subdir, (E) `build-config-prop.sh` emits `app.project.path=` only when `--app-project-path` is passed.
 
 ## Notes
 

--- a/skills/create-project/scripts/build-config-prop.sh
+++ b/skills/create-project/scripts/build-config-prop.sh
@@ -13,16 +13,25 @@ Options:
   --codegen-type JAVA|CPP       Code generation type (default: JAVA)
   --process-timer <duration>    app.process.timer value (default: 1s)
   --mvn-args <string>           Maven extra args (default: empty)
+  --app-project-path <path>     Existing app project path (UPDATE_SDK_APP only).
+                                When set, a `app.project.path=<value>` line is
+                                emitted. Omit for GENERATE_SDK_APP.
   --output <path>               Output file path (required)
   --help                        Show this help
 
-Output format (exactly as PDF spec):
+Output format for GENERATE_SDK_APP (PDF §3):
   fd.project.path=/workspace/<ProjectName>/com.bosch.fsp.<ProjectName>
   codegen.type=JAVA
   mvn.args=
   app.project.name=<AppName>
   app.skeleton.name=<AppName>
   app.process.timer=1s
+
+Output format for UPDATE_SDK_APP (PDF §4) adds one line:
+  fd.project.path=/workspace/<ProjectName>/com.bosch.fsp.<ProjectName>
+  app.project.path=/workspace/<ProjectName>/<ProjectName>_<AppName>
+  codegen.type=CPP
+  ... (rest identical)
 EOF
 }
 
@@ -31,6 +40,7 @@ APP_PROJECT_NAME=""
 CODEGEN_TYPE="JAVA"
 PROCESS_TIMER="1s"
 MVN_ARGS=""
+APP_PROJECT_PATH=""
 OUTPUT=""
 
 if [[ $# -eq 0 ]]; then
@@ -45,6 +55,7 @@ while [[ $# -gt 0 ]]; do
     --codegen-type)      CODEGEN_TYPE="${2:-}"; shift 2 ;;
     --process-timer)     PROCESS_TIMER="${2:-}"; shift 2 ;;
     --mvn-args)          MVN_ARGS="${2:-}"; shift 2 ;;
+    --app-project-path)  APP_PROJECT_PATH="${2:-}"; shift 2 ;;
     --output)            OUTPUT="${2:-}"; shift 2 ;;
     --help|-h)           usage; exit 0 ;;
     *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 64 ;;
@@ -71,13 +82,19 @@ case "$CODEGEN_TYPE" in
 esac
 
 # Write config.prop — container paths only (fd.project.path uses /workspace/...)
-cat > "$OUTPUT" <<EOF
-fd.project.path=/workspace/${PROJECT_NAME}/com.bosch.fsp.${PROJECT_NAME}
-codegen.type=${CODEGEN_TYPE}
-mvn.args=${MVN_ARGS}
-app.project.name=${APP_PROJECT_NAME}
-app.skeleton.name=${APP_PROJECT_NAME}
-app.process.timer=${PROCESS_TIMER}
-EOF
+# UPDATE_SDK_APP (PDF §4) requires an extra `app.project.path` line pointing at
+# the existing app project; GENERATE_SDK_APP (PDF §3) omits it. We keep a single
+# script and switch on --app-project-path.
+{
+  echo "fd.project.path=/workspace/${PROJECT_NAME}/com.bosch.fsp.${PROJECT_NAME}"
+  if [[ -n "$APP_PROJECT_PATH" ]]; then
+    echo "app.project.path=${APP_PROJECT_PATH}"
+  fi
+  echo "codegen.type=${CODEGEN_TYPE}"
+  echo "mvn.args=${MVN_ARGS}"
+  echo "app.project.name=${APP_PROJECT_NAME}"
+  echo "app.skeleton.name=${APP_PROJECT_NAME}"
+  echo "app.process.timer=${PROCESS_TIMER}"
+} > "$OUTPUT"
 
 echo "[build-config-prop] written: $OUTPUT"

--- a/skills/regen-sdk-app/SKILL.md
+++ b/skills/regen-sdk-app/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: regen-sdk-app
+description: Re-run FD Headless UPDATE_SDK_APP on an existing SeamOS project to refresh the generated SDK/skeleton layer while preserving the user's hand-written app code. Use this skill whenever the user says "SDK 재생성", "APP 재생성", "SDK 업데이트", "skeleton 갱신", "FSP 바뀌었는데 앱에 반영", "인터페이스 바꿨는데 앱", "interface 반영", "regen sdk", "regen app", "re-sync SDK", "UPDATE_SDK_APP", or similar phrasings. Also use when the user has an existing create-project workspace, modified their FSP, and wants the generated SDK + skeleton layer merged into the existing app project WITHOUT losing their custom code. Do NOT use this for uploading a new marketplace version — that is `update-app` (different layer entirely).
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit
+argument-hint: "[--project-name NAME] [--codegen-type JAVA|CPP] [--dry-run]"
+---
+
+# Regenerate SDK + APP Skeleton (FD Headless UPDATE_SDK_APP)
+
+Re-runs FD Headless in **UPDATE_SDK_APP** mode against an existing workspace. Bosch's contract: the FSP project is read as-is, and the generated SDK hooks + skeleton wiring are merged into the **existing** app project — your own source files are preserved.
+
+## When to Use This vs. Alternatives
+
+| Scenario | Skill |
+|---|---|
+| Brand-new project, no workspace yet | `create-project` (Stage 1A + 1B) |
+| FSP/interface unchanged, just want a clean app skeleton from scratch | `create-project --resume` (re-runs Stage 1B = GENERATE_SDK_APP — **destroys** local app edits) |
+| FSP changed (via regenerated FSP) → merge into existing app project, keep user code | **this skill** (`regen-sdk-app`) |
+| Interface JSON itself changed — FSP must be regenerated first | `create-project --force-clean` **then** `regen-sdk-app` |
+| Upload a new `.fif` version to the SDM marketplace | `update-app` — wrong layer, different concept |
+
+## Prerequisites
+
+1. **USER_ROOT**: a directory containing `.mcp.json` (discovered by upward traversal from `$PWD`).
+2. **Context populated**: `$USER_ROOT/.seamos-context.json` must have `last_project.{name, workspace_path, app_project_name, codegen_type, app_project_path, sdk_app_completed_at}`. This means `create-project` (including Stage 1B) was already executed successfully. If context is missing or stale, tell the user to run `create-project` first.
+3. **FSP current**: Whatever is in `<workspace>/<PROJECT>/com.bosch.fsp.<PROJECT>/` is taken as truth. This skill will NOT touch the FSP or re-validate interface JSON. If the user's reason for regen is "I changed interface.json", route them to `create-project --force-clean` first.
+4. **Docker**: running with the pinned image `seamos-fd-headless:0.4.2` (or local build / `--image-tag` override).
+
+## Execution Flow
+
+### Step 1: Resolve USER_ROOT + context
+
+```bash
+USER_ROOT=$(find_user_root)                  # upward search for .mcp.json
+CONTEXT="$USER_ROOT/.seamos-context.json"
+```
+
+If either is missing → exit 64 with the corrective command to run.
+
+### Step 2: Derive parameters
+
+Read from context; CLI flags override. Required fields and resolution order:
+
+| Field | Flag | Context key | Fallback |
+|---|---|---|---|
+| `PROJECT_NAME` | `--project-name` | `last_project.name` | error exit 64 |
+| `APP_PROJECT_NAME` | `--app-project-name` | `last_project.app_project_name` | = `PROJECT_NAME` |
+| `CODEGEN_TYPE` | `--codegen-type` | `last_project.codegen_type` | `JAVA` |
+| `PROCESS_TIMER` | `--process-timer` | `last_project.process_timer` | `1s` |
+| `MVN_ARGS` | `--mvn-args` | `last_project.mvn_args` | `""` |
+| `APP_PROJECT_PATH` | `--app-project-path` (host path) | `last_project.app_project_path` | error exit 64 |
+| `WORKSPACE` | — | `last_project.workspace_path` | error exit 64 |
+
+**Why `APP_PROJECT_PATH` is required without a fallback**: Bosch's UPDATE_SDK_APP needs to know where the existing app project lives. Unlike GENERATE, it cannot infer — the path may have been renamed, and it is the sole difference vs. GENERATE in the config.prop schema (PDF §4).
+
+### Step 3: Write config.prop
+
+Delegate to the shared helper (shared with `create-project` Stage 1B):
+
+```bash
+bash ../create-project/scripts/build-config-prop.sh \
+  --project-name      "$PROJECT_NAME" \
+  --app-project-name  "$APP_PROJECT_NAME" \
+  --codegen-type      "$CODEGEN_TYPE" \
+  --process-timer     "$PROCESS_TIMER" \
+  --mvn-args          "$MVN_ARGS" \
+  --app-project-path  "/workspace/$PROJECT_NAME/${PROJECT_NAME}_${APP_PROJECT_NAME}" \
+  --output            "$WORKSPACE/_config.prop"
+```
+
+The `--app-project-path` flag (optional on the helper) is what flips config.prop from GENERATE format to UPDATE format by adding the `app.project.path=...` line. Always pass the **container-internal** path (`/workspace/...`) — the `-v` mount handles the host mapping.
+
+### Step 4: docker run UPDATE_SDK_APP
+
+Same pattern as Stage 1B, but with `FD_OPERATION=UPDATE_SDK_APP`:
+
+```bash
+timeout 600 docker run --rm --platform linux/amd64 \
+  -v "$WORKSPACE:/workspace" \
+  -e FD_WORKSPACE=/workspace \
+  -e FD_OPERATION=UPDATE_SDK_APP \
+  -e FD_CONFIG_PROP=/workspace/_config.prop \
+  "$IMAGE_TAG" 2>&1 | tee "$WORKSPACE/run-sdk-app-update.log"
+```
+
+The entrypoint (`docker/fd-headless/entrypoint.sh`) already branches `GENERATE_SDK_APP|UPDATE_SDK_APP` together, so no image changes are required.
+
+**Success detection**: grep the log for FD's exit markers — `FD HEADLESS EXECUTION COMPLETED SUCCESSFULLY` vs. `FD HEADLESS EXECUTION EXITED WITH ERRORS`.
+
+### Step 5: Context upsert on success
+
+Merge-write (preserving all other fields):
+
+```json
+{
+  "last_project": {
+    "operation": "UPDATE_SDK_APP",
+    "sdk_app_updated_at": "<ISO-8601 UTC>"
+  }
+}
+```
+
+Rationale for a **new** `sdk_app_updated_at` field (not overwriting `sdk_app_completed_at`): the original Stage 1B completion timestamp remains as the "first generation" marker; each UPDATE_SDK_APP run refreshes only `_updated_at`. This matches the semantics in `shared-references/seamos-context-cache.md` (field ownership: each skill owns its own timestamp).
+
+Use the same `acquire_context_lock` pattern (flock → mkdir fallback → `.tmp` + `mv`) as the rest of the suite to stay concurrency-safe.
+
+### Step 6: Dry-run mode (`--dry-run`)
+
+No docker invocation, no disk mutation. Emit these path variables to stdout (mirrors create-project's convention for the smoke harness):
+
+```
+[dry-run] USER_ROOT=...
+[dry-run] PROJECT_NAME=...
+[dry-run] WORKSPACE=...
+[dry-run] FSP_PATH=...
+[dry-run] APP_PROJECT_PATH=...            # host path
+[dry-run] APP_PROJECT_PATH_CONTAINER=...  # /workspace/... path written into config.prop
+[dry-run] CONFIG_PROP=...
+[dry-run] CONTEXT_FILE=...
+[dry-run] operation=UPDATE_SDK_APP codegen_type=<...>
+[dry-run] docker cmd: timeout 600 docker run --rm ... seamos-fd-headless:0.4.2
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | UPDATE_SDK_APP succeeded, context updated |
+| 1 | FD Headless reported `EXITED WITH ERRORS` (see `run-sdk-app-update.log`) |
+| 2 | FD log contained neither success nor failure marker (investigate) |
+| 3 | `timeout` fired (600s) |
+| 64 | Usage error — missing context, missing `app_project_path`, invalid flags |
+| 69 | Docker image unavailable (pull failed and not cached locally) |
+
+## Important Notes
+
+- **This skill refuses to run FSP regeneration**. FSP drift is handled explicitly by `create-project --force-clean` to keep responsibilities clean (single-responsibility per skill). If the user mentions interface changes, surface the two-step recipe instead of silently chaining.
+- **Backing up app code**: UPDATE_SDK_APP is supposed to preserve your source, but since we cannot audit Bosch's merge logic, suggest the user commit or snapshot `<WORKSPACE>/<PROJECT>/<PROJECT>_<APP>/` before running — especially on the first use.
+- **`build-config-prop.sh` is shared** with `create-project` and lives under `skills/create-project/scripts/`. The only difference: this skill always passes `--app-project-path`; `create-project` Stage 1B never does.
+- **Context schema**: see `skills/shared-references/seamos-context-cache.md` — this skill adds `sdk_app_updated_at` (preserves `sdk_app_completed_at`).
+- **Shared rules for FD image pinning, `timeout` fallback (`gtimeout`), and Rosetta 2**: see the `Prerequisites` + `ensure_image` sections of `skills/create-project/SKILL.md` — the same invariants apply here.

--- a/skills/regen-sdk-app/evals/evals.json
+++ b/skills/regen-sdk-app/evals/evals.json
@@ -1,0 +1,72 @@
+{
+  "skill_name": "regen-sdk-app",
+  "evals": [
+    {
+      "id": 1,
+      "name": "happy-path-from-context",
+      "prompt": "내 SeamOS 프로젝트에서 FSP를 살짝 수정했는데, 기존 앱 코드는 건드리지 말고 SDK랑 skeleton만 최신 FSP에 맞춰서 재생성해줘. create-project는 전에 한 번 돌렸고 .seamos-context.json 에 마지막 프로젝트 정보 다 있어.",
+      "expected_output": "Claude should invoke regen-sdk-app skill (not update-app, not create-project). It should read .seamos-context.json, derive PROJECT_NAME/APP_PROJECT_NAME/CODEGEN_TYPE/APP_PROJECT_PATH from last_project.*, build config.prop with the extra app.project.path line (container path /workspace/...), and run docker with FD_OPERATION=UPDATE_SDK_APP.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "triggers-regen-sdk-app",
+          "description": "Invokes regen-sdk-app skill rather than update-app or create-project"
+        },
+        {
+          "id": "reads-context",
+          "description": "Reads .seamos-context.json and uses last_project.app_project_path"
+        },
+        {
+          "id": "operation-update-sdk-app",
+          "description": "The docker invocation uses FD_OPERATION=UPDATE_SDK_APP (not GENERATE_SDK_APP)"
+        },
+        {
+          "id": "config-prop-has-app-project-path",
+          "description": "The generated _config.prop contains an `app.project.path=` line pointing at /workspace/<PROJECT>/<PROJECT>_<APP>"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "missing-context-guidance",
+      "prompt": "앱 스켈레톤 갱신해줘",
+      "expected_output": "The user's project has no .seamos-context.json (or no last_project.app_project_path). The skill should detect this and tell the user to run create-project first — not silently fail or guess defaults. Exit code 64 is correct.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "detects-missing-context",
+          "description": "Detects that context file or required fields are missing"
+        },
+        {
+          "id": "routes-to-create-project",
+          "description": "Surfaces guidance to run `create-project` first rather than attempting to guess app_project_path"
+        },
+        {
+          "id": "exits-64-on-missing",
+          "description": "Script exits with code 64 (usage error) when app_project_path cannot be resolved"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "interface-changed-routing",
+      "prompt": "interface.json에 새 branch를 하나 추가했어. 이것까지 반영해서 SDK/APP 업데이트해줘.",
+      "expected_output": "Changing interface.json invalidates the FSP — UPDATE_SDK_APP alone won't pick up new branches because it reads the FSP as-is. Claude should recognize this and explain the two-step recipe: (1) `create-project --force-clean` to regenerate FSP from the updated interface, then (2) `regen-sdk-app` to merge into the existing app. It should NOT silently run regen-sdk-app (which would produce a stale result).",
+      "files": [],
+      "assertions": [
+        {
+          "id": "recognizes-fsp-drift",
+          "description": "Recognizes that interface.json change requires FSP regeneration, not just UPDATE_SDK_APP"
+        },
+        {
+          "id": "proposes-two-step-recipe",
+          "description": "Proposes create-project --force-clean THEN regen-sdk-app (in that order), rather than running regen-sdk-app alone"
+        },
+        {
+          "id": "warns-about-app-backup",
+          "description": "Mentions that --force-clean preserves seamos-assets/SSOT but the user may want to commit/snapshot app code first (since create-project's Stage 1B regenerates the skeleton)"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/regen-sdk-app/evals/smoke.sh
+++ b/skills/regen-sdk-app/evals/smoke.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# smoke.sh — Docker-free smoke test for regen-sdk-app skill.
+# Exercises the path-resolution / context-reading / config.prop-emission logic
+# via --dry-run on a temporary fixture USER_ROOT. No docker, no FD invocation.
+#
+# Runs 4 scenarios:
+#   A. missing context         → exit 64, mentions create-project
+#   B. partial context         → exit 64, enumerates missing fields
+#   C. full context, dry-run   → exit 0, emits all 10 path variables + docker cmd
+#   D. invoked from subdir     → USER_ROOT resolves via upward .mcp.json search
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/regen-sdk-app.sh"
+BUILD_CFG="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/create-project/scripts/build-config-prop.sh"
+
+FIXT="$(mktemp -d /tmp/regen-sdk-app-smoke.XXXXXX)"
+cleanup() {
+  find "$FIXT" -type f -delete 2>/dev/null || true
+  find "$FIXT" -depth -type d -empty -delete 2>/dev/null || true
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+assert() {
+  local label="$1" cond="$2"
+  if eval "$cond"; then
+    echo "  [PASS] $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] $label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+cd "$FIXT"
+touch .mcp.json
+
+# ─── Case A: missing context ───────────────────────────────────────────────
+echo "=== Case A: missing context file ==="
+set +e
+OUT_A="$(bash "$SCRIPT" --dry-run 2>&1)"
+EXIT_A=$?
+set -e
+assert "Case A exits 64"               '[[ $EXIT_A -eq 64 ]]'
+assert "Case A mentions create-project" '[[ "$OUT_A" == *create-project* ]]'
+
+# ─── Case B: partial context, no app_project_path ─────────────────────────
+echo "=== Case B: partial context ==="
+cat > .seamos-context.json <<JSON
+{"last_project":{"name":"MyProj","workspace_path":"$FIXT"}}
+JSON
+set +e
+OUT_B="$(bash "$SCRIPT" --dry-run 2>&1)"
+EXIT_B=$?
+set -e
+assert "Case B exits 64"                      '[[ $EXIT_B -eq 64 ]]'
+assert "Case B lists APP_PROJECT_PATH missing" '[[ "$OUT_B" == *APP_PROJECT_PATH* ]]'
+
+# ─── Case C: full context, dry-run happy path ─────────────────────────────
+echo "=== Case C: full context ==="
+cat > .seamos-context.json <<JSON
+{
+  "last_project": {
+    "name": "MyProj",
+    "workspace_path": "$FIXT",
+    "app_project_name": "MyApp",
+    "codegen_type": "CPP",
+    "app_project_path": "$FIXT/MyProj/MyProj_MyApp",
+    "sdk_app_completed_at": "2026-04-23T00:00:00Z"
+  }
+}
+JSON
+set +e
+OUT_C="$(bash "$SCRIPT" --dry-run 2>&1)"
+EXIT_C=$?
+set -e
+assert "Case C exits 0"                               '[[ $EXIT_C -eq 0 ]]'
+assert "Case C emits USER_ROOT="                      '[[ "$OUT_C" == *USER_ROOT=* ]]'
+assert "Case C emits PROJECT_NAME=MyProj"             '[[ "$OUT_C" == *PROJECT_NAME=MyProj* ]]'
+assert "Case C emits WORKSPACE="                      '[[ "$OUT_C" == *WORKSPACE=* ]]'
+assert "Case C emits FSP_PATH="                       '[[ "$OUT_C" == *FSP_PATH=* ]]'
+assert "Case C emits APP_PROJECT_PATH="               '[[ "$OUT_C" == *APP_PROJECT_PATH=* ]]'
+assert "Case C emits container app path /workspace/"  '[[ "$OUT_C" == *APP_PROJECT_PATH_CONTAINER=/workspace/MyProj/MyProj_MyApp* ]]'
+assert "Case C emits CONFIG_PROP="                    '[[ "$OUT_C" == *CONFIG_PROP=* ]]'
+assert "Case C emits CONTEXT_FILE="                   '[[ "$OUT_C" == *CONTEXT_FILE=* ]]'
+assert "Case C docker cmd uses UPDATE_SDK_APP"        '[[ "$OUT_C" == *FD_OPERATION=UPDATE_SDK_APP* ]]'
+assert "Case C codegen_type=CPP (from context)"       '[[ "$OUT_C" == *codegen_type=CPP* ]]'
+
+# ─── Case D: invoked from nested subdir ───────────────────────────────────
+echo "=== Case D: invoked from nested subdir ==="
+mkdir -p "$FIXT/deep/nest"
+cd "$FIXT/deep/nest"
+set +e
+OUT_D="$(bash "$SCRIPT" --dry-run 2>&1)"
+EXIT_D=$?
+set -e
+cd "$FIXT"
+assert "Case D exits 0 (upward .mcp.json search)" '[[ $EXIT_D -eq 0 ]]'
+assert "Case D USER_ROOT resolves to fixture"     '[[ "$OUT_D" == *USER_ROOT=*$(basename "$FIXT")* ]]'
+
+# ─── Case E: build-config-prop backward compat (no --app-project-path) ─────
+echo "=== Case E: build-config-prop backward compat ==="
+OUT_CFG="$(bash "$BUILD_CFG" --project-name X --app-project-name Y --codegen-type JAVA --output /dev/stdout 2>/dev/null || true)"
+assert "Case E GENERATE mode has no app.project.path line"        '[[ "$OUT_CFG" != *app.project.path=* ]]'
+OUT_CFG_U="$(bash "$BUILD_CFG" --project-name X --app-project-name Y --codegen-type JAVA --app-project-path /workspace/X/X_Y --output /dev/stdout 2>/dev/null || true)"
+assert "Case E UPDATE mode has app.project.path=/workspace/X/X_Y" '[[ "$OUT_CFG_U" == *app.project.path=/workspace/X/X_Y* ]]'
+
+echo ""
+echo "=== smoke: $PASS passed, $FAIL failed ==="
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+echo "=== smoke OK ==="

--- a/skills/regen-sdk-app/scripts/regen-sdk-app.sh
+++ b/skills/regen-sdk-app/scripts/regen-sdk-app.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# regen-sdk-app.sh — Re-run FD Headless UPDATE_SDK_APP on an existing workspace.
+#
+# Refreshes the generated SDK hooks + skeleton wiring in an existing app project
+# while preserving the user's hand-written code. Reads context from
+# $USER_ROOT/.seamos-context.json (written by create-project Stage 1B).
+#
+# Usage:
+#   regen-sdk-app.sh [flags]
+#
+# Flags:
+#   --project-name NAME         FSP project (overrides context.last_project.name)
+#   --app-project-name NAME     App project (overrides context)
+#   --codegen-type JAVA|CPP     (overrides context; defaults to JAVA if neither)
+#   --app-project-path PATH     Host path to existing app project (overrides
+#                               context; required if context missing)
+#   --process-timer DUR         app.process.timer (default from context or 1s)
+#   --mvn-args STR              Extra Maven args (default from context or empty)
+#   --image-tag TAG             Docker image (default: seamos-fd-headless:0.4.2)
+#   --dry-run                   Print resolved paths + docker cmd, do not run
+#   --help                      Show this help
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── find_user_root (mirror create-project) ────────────────────────────────
+find_user_root() {
+  local dir
+  dir="$(pwd -P)"
+  while true; do
+    if [[ -f "$dir/.mcp.json" ]]; then
+      echo "$dir"; return 0
+    fi
+    [[ "$dir" == "/" ]] && break
+    dir="$(dirname "$dir")"
+  done
+  if [[ "${SEAMOS_ALLOW_PWD_FALLBACK:-0}" == "1" ]]; then
+    echo "WARN: no .mcp.json found upward from \$PWD — using \$PWD (test fallback)" >&2
+    pwd -P; return 0
+  fi
+  echo "ERROR: no .mcp.json found upward from \$PWD" >&2
+  echo "       regen-sdk-app requires a USER_ROOT marked by .mcp.json." >&2
+  echo "       Run \`touch .mcp.json\` in your project root or cd there." >&2
+  return 64
+}
+
+# ─── acquire_context_lock (flock → mkdir fallback) ─────────────────────────
+acquire_context_lock() {
+  local target="$1"
+  local fd=9
+  if command -v flock >/dev/null 2>&1; then
+    # shellcheck disable=SC3013
+    exec {fd}>"${target}.lock"
+    flock -x "$fd"
+    return 0
+  fi
+  local lockdir="${target}.lock.d"
+  local tries=0
+  while ! mkdir "$lockdir" 2>/dev/null; do
+    tries=$((tries + 1))
+    if (( tries > 300 )); then
+      echo "ERROR: lock timeout on $lockdir" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  # Auto-release on script exit
+  # shellcheck disable=SC2064
+  trap "rmdir '$lockdir' 2>/dev/null || true" EXIT
+  return 0
+}
+
+# ─── Arg parsing ───────────────────────────────────────────────────────────
+usage() {
+  sed -n '3,21p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+PROJECT_NAME=""
+APP_PROJECT_NAME=""
+CODEGEN_TYPE=""
+APP_PROJECT_PATH=""   # host path
+PROCESS_TIMER=""
+MVN_ARGS=""
+IMAGE_TAG="seamos-fd-headless:0.4.2"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-name)      PROJECT_NAME="${2:-}"; shift 2 ;;
+    --app-project-name)  APP_PROJECT_NAME="${2:-}"; shift 2 ;;
+    --codegen-type)      CODEGEN_TYPE="${2:-}"; shift 2 ;;
+    --app-project-path)  APP_PROJECT_PATH="${2:-}"; shift 2 ;;
+    --process-timer)     PROCESS_TIMER="${2:-}"; shift 2 ;;
+    --mvn-args)          MVN_ARGS="${2:-}"; shift 2 ;;
+    --image-tag)         IMAGE_TAG="${2:-}"; shift 2 ;;
+    --dry-run)           DRY_RUN=1; shift ;;
+    --help|-h)           usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+# ─── Resolve USER_ROOT + context ───────────────────────────────────────────
+USER_ROOT="$(find_user_root)"
+CONTEXT_FILE="$USER_ROOT/.seamos-context.json"
+
+if [[ ! -f "$CONTEXT_FILE" ]]; then
+  echo "ERROR: context file not found: $CONTEXT_FILE" >&2
+  echo "       UPDATE_SDK_APP requires an existing project — run create-project first." >&2
+  exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 64
+fi
+
+# Helper: context lookup with empty-on-missing
+ctx() { jq -r "$1 // empty" "$CONTEXT_FILE"; }
+
+# Flag > context > fallback/error
+PROJECT_NAME="${PROJECT_NAME:-$(ctx '.last_project.name')}"
+APP_PROJECT_NAME="${APP_PROJECT_NAME:-$(ctx '.last_project.app_project_name')}"
+CODEGEN_TYPE="${CODEGEN_TYPE:-$(ctx '.last_project.codegen_type')}"
+APP_PROJECT_PATH="${APP_PROJECT_PATH:-$(ctx '.last_project.app_project_path')}"
+PROCESS_TIMER="${PROCESS_TIMER:-$(ctx '.last_project.process_timer')}"
+MVN_ARGS="${MVN_ARGS:-$(ctx '.last_project.mvn_args')}"
+WORKSPACE="$(ctx '.last_project.workspace_path')"
+
+# Apply silent defaults for truly optional fields
+[[ -z "$CODEGEN_TYPE"   ]] && CODEGEN_TYPE="JAVA"
+[[ -z "$PROCESS_TIMER"  ]] && PROCESS_TIMER="1s"
+[[ -z "$APP_PROJECT_NAME" ]] && APP_PROJECT_NAME="$PROJECT_NAME"
+
+# Hard-required fields (no silent defaults — surface the error)
+MISSING=()
+[[ -z "$PROJECT_NAME"     ]] && MISSING+=("PROJECT_NAME (--project-name or context.last_project.name)")
+[[ -z "$WORKSPACE"        ]] && MISSING+=("WORKSPACE (context.last_project.workspace_path)")
+[[ -z "$APP_PROJECT_PATH" ]] && MISSING+=("APP_PROJECT_PATH (--app-project-path or context.last_project.app_project_path)")
+
+if (( ${#MISSING[@]} > 0 )); then
+  echo "ERROR: missing required parameters for UPDATE_SDK_APP:" >&2
+  for m in "${MISSING[@]}"; do
+    echo "  - $m" >&2
+  done
+  echo >&2
+  echo "Fix:" >&2
+  echo "  1. Run \`create-project\` (including Stage 1B) to populate context, OR" >&2
+  echo "  2. Pass the missing fields as CLI flags." >&2
+  exit 64
+fi
+
+case "$CODEGEN_TYPE" in
+  JAVA|CPP) ;;
+  *) echo "ERROR: --codegen-type must be JAVA or CPP (got: $CODEGEN_TYPE)" >&2; exit 64 ;;
+esac
+
+# ─── Derived paths ─────────────────────────────────────────────────────────
+FSP_PATH="$WORKSPACE/$PROJECT_NAME/com.bosch.fsp.$PROJECT_NAME"
+# Container-internal path written into config.prop. Bosch's UPDATE_SDK_APP
+# requires this path relative to FD_WORKSPACE (mounted as /workspace).
+APP_PROJECT_PATH_CONTAINER="/workspace/$PROJECT_NAME/${PROJECT_NAME}_${APP_PROJECT_NAME}"
+CONFIG_PROP="$WORKSPACE/_config.prop"
+LOG="$WORKSPACE/run-sdk-app-update.log"
+
+# Resolve timeout binary (macOS users installing coreutils get gtimeout)
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN=gtimeout
+else
+  echo "ERROR: neither 'timeout' nor 'gtimeout' found. Install coreutils." >&2
+  exit 64
+fi
+
+DOCKER_CMD=(
+  "$TIMEOUT_BIN" 600
+  docker run --rm --platform linux/amd64
+  -v "${WORKSPACE}:/workspace"
+  -e FD_WORKSPACE=/workspace
+  -e FD_OPERATION=UPDATE_SDK_APP
+  -e FD_CONFIG_PROP=/workspace/_config.prop
+  "$IMAGE_TAG"
+)
+
+# ─── Dry-run output ────────────────────────────────────────────────────────
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "[dry-run] USER_ROOT=$USER_ROOT"
+  echo "[dry-run] PROJECT_NAME=$PROJECT_NAME"
+  echo "[dry-run] APP_PROJECT_NAME=$APP_PROJECT_NAME"
+  echo "[dry-run] WORKSPACE=$WORKSPACE"
+  echo "[dry-run] FSP_PATH=$FSP_PATH"
+  echo "[dry-run] APP_PROJECT_PATH=$APP_PROJECT_PATH"
+  echo "[dry-run] APP_PROJECT_PATH_CONTAINER=$APP_PROJECT_PATH_CONTAINER"
+  echo "[dry-run] CONFIG_PROP=$CONFIG_PROP"
+  echo "[dry-run] CONTEXT_FILE=$CONTEXT_FILE"
+  echo "[dry-run] operation=UPDATE_SDK_APP codegen_type=$CODEGEN_TYPE image=$IMAGE_TAG"
+  echo "[dry-run] docker cmd: ${DOCKER_CMD[*]}"
+  exit 0
+fi
+
+# ─── Pre-flight: workspace + FSP must already exist ────────────────────────
+if [[ ! -d "$WORKSPACE" ]]; then
+  echo "ERROR: workspace does not exist: $WORKSPACE" >&2
+  echo "       Run create-project first." >&2
+  exit 64
+fi
+if [[ ! -d "$FSP_PATH" ]]; then
+  echo "ERROR: FSP project not found: $FSP_PATH" >&2
+  echo "       The FSP must already be current. If interface.json changed," >&2
+  echo "       run \`create-project --force-clean\` first to regenerate the FSP." >&2
+  exit 64
+fi
+
+# ─── Write config.prop (delegates to shared helper) ─────────────────────────
+BUILD_CONFIG="$SCRIPT_DIR/../../create-project/scripts/build-config-prop.sh"
+if [[ ! -x "$BUILD_CONFIG" ]]; then
+  echo "ERROR: build-config-prop.sh not found or not executable at $BUILD_CONFIG" >&2
+  exit 1
+fi
+
+bash "$BUILD_CONFIG" \
+  --project-name      "$PROJECT_NAME" \
+  --app-project-name  "$APP_PROJECT_NAME" \
+  --codegen-type      "$CODEGEN_TYPE" \
+  --process-timer     "$PROCESS_TIMER" \
+  --mvn-args          "$MVN_ARGS" \
+  --app-project-path  "$APP_PROJECT_PATH_CONTAINER" \
+  --output            "$CONFIG_PROP"
+
+# ─── ensure_image ──────────────────────────────────────────────────────────
+ensure_image() {
+  local tag="$1"
+  if docker image inspect "$tag" >/dev/null 2>&1; then
+    echo "[image] using local: $tag" >&2
+    return 0
+  fi
+  echo "[image] not found locally, attempting pull: $tag" >&2
+  if docker pull --platform linux/amd64 "$tag"; then
+    return 0
+  fi
+  echo "WARN: docker pull failed for $tag. Re-checking local cache..." >&2
+  if docker image inspect "$tag" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "ERROR: image not available locally and pull failed: $tag" >&2
+  return 69
+}
+ensure_image "$IMAGE_TAG" || exit 69
+
+# ─── Run UPDATE_SDK_APP ────────────────────────────────────────────────────
+set +e
+"${DOCKER_CMD[@]}" 2>&1 | tee "$LOG"
+RUN_STATUS=${PIPESTATUS[0]}
+set -e
+
+if [[ $RUN_STATUS -eq 124 ]]; then
+  echo "ERROR: UPDATE_SDK_APP run timed out after 600s" >&2
+  exit 3
+fi
+
+if grep -qF "FD HEADLESS EXECUTION COMPLETED SUCCESSFULLY" "$LOG"; then
+  FINAL=0
+elif grep -qF "FD HEADLESS EXECUTION EXITED WITH ERRORS" "$LOG"; then
+  FINAL=1
+else
+  FINAL=2
+fi
+
+if [[ $FINAL -ne 0 ]]; then
+  echo "[regen-sdk-app] UPDATE_SDK_APP failed (exit $FINAL) — see $LOG" >&2
+  exit "$FINAL"
+fi
+
+# ─── Context upsert on success ─────────────────────────────────────────────
+UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+PAYLOAD=$(jq -n \
+  --arg operation "UPDATE_SDK_APP" \
+  --arg sdk_app_updated_at "$UPDATED_AT" \
+  '{operation:$operation, sdk_app_updated_at:$sdk_app_updated_at}')
+
+(
+  acquire_context_lock "$CONTEXT_FILE" || { echo "ERROR: failed to acquire context lock" >&2; exit 1; }
+  TMP="${CONTEXT_FILE}.tmp.$$"
+  jq --argjson p "$PAYLOAD" 'if .last_project then (.last_project += $p) else (.last_project = $p) end' "$CONTEXT_FILE" > "$TMP"
+  mv "$TMP" "$CONTEXT_FILE"
+)
+
+echo "[regen-sdk-app] UPDATE_SDK_APP succeeded"
+echo "[regen-sdk-app] context updated: operation=UPDATE_SDK_APP sdk_app_updated_at=$UPDATED_AT"
+exit 0

--- a/skills/shared-references/seamos-context-cache.md
+++ b/skills/shared-references/seamos-context-cache.md
@@ -111,19 +111,20 @@ Example for `manage-device-app`:
 
 `skills/create-project/` 스킬이 성공 종료 시 `$USER_ROOT/.seamos-context.json` 의 `last_project` 키를 atomic merge upsert 한다 (`flock` 또는 `mkdir`-폴백 + `.tmp` + `mv`). Stage 1A(FSP) 와 Stage 1B(SDK/APP) 단계 각각이 완료 시점에 관련 필드를 추가하고, 기존 필드는 보존된다.
 
-### Schema (최종 — FSP + SDK/APP 모두 완료 후)
+### Schema (최종 — FSP + SDK/APP 모두 완료 후, regen-sdk-app 반영)
 
 ```json
 {
   "last_project": {
     "name": "<project-name>",
     "workspace_path": "<abs-path>",
-    "operation": "GENERATE_SDK_APP",
+    "operation": "GENERATE_SDK_APP | UPDATE_SDK_APP",
     "image_tag": "public.ecr.aws/g0j5z0m9/seamos-fd-headless:0.4.2",
     "interface_json_sha256": "<64-hex>",
     "created_at": "<ISO-8601 UTC>",
     "fsp_completed_at": "<ISO-8601 UTC>",
     "sdk_app_completed_at": "<ISO-8601 UTC>",
+    "sdk_app_updated_at": "<ISO-8601 UTC>",
     "app_project_name": "<app-project-name>",
     "codegen_type": "JAVA" | "CPP",
     "app_project_path": "<USER_ROOT>/<PROJECT>/<PROJECT>/<PROJECT>_<APP_NAME>"
@@ -136,10 +137,11 @@ Example for `manage-device-app`:
 | Field | Written at | Purpose |
 |-------|-----------|---------|
 | `name`, `workspace_path`, `image_tag`, `interface_json_sha256`, `created_at` | Stage 1A success | FSP bookkeeping |
-| `operation` | Both stages | Last executed FD operation |
+| `operation` | Both stages + regen-sdk-app | Last executed FD operation |
 | `fsp_completed_at` | Stage 1A success | FSP completion timestamp (resume discriminator) |
-| `sdk_app_completed_at` | Stage 1B success | SDK/APP completion timestamp (resume discriminator) |
-| `app_project_name`, `codegen_type`, `app_project_path` | Stage 1B success | Maven / CMake target resolution |
+| `sdk_app_completed_at` | Stage 1B success | SDK/APP **first** completion timestamp (resume discriminator; preserved across re-runs) |
+| `sdk_app_updated_at` | `regen-sdk-app` success (UPDATE_SDK_APP) | Last UPDATE_SDK_APP run — refreshed each time skeleton is merged |
+| `app_project_name`, `codegen_type`, `app_project_path` | Stage 1B success | Maven / CMake target resolution (read by `regen-sdk-app` and `build-fif`) |
 
 ### Resume decision matrix
 
@@ -174,6 +176,8 @@ jq -e '.last_project.fsp_completed_at and .last_project.sdk_app_completed_at' \
 ```
 
 `build-fif` uses `app_project_path`'s parent-of-parent as `FD_APP_ROOT`; `upload-app` does not read context directly (it scans `$USER_ROOT/seamos-assets/`).
+
+`regen-sdk-app` reads `app_project_path`, `app_project_name`, `codegen_type`, and `workspace_path` from `last_project`, runs `FD_OPERATION=UPDATE_SDK_APP`, and on success writes back `operation=UPDATE_SDK_APP` + `sdk_app_updated_at` without touching `sdk_app_completed_at` (the original Stage 1B completion marker is preserved).
 
 ### Concurrency
 


### PR DESCRIPTION
## Summary

FD Headless의 세 번째 operation인 **`UPDATE_SDK_APP`**(PDF §4)를 위한 신규 스킬 `regen-sdk-app`. 기존 앱 소스 코드는 그대로 두고 FSP 변경분을 SDK hooks + skeleton 배선에만 반영하는 머지 동작을 감싼다.

- **신규 operation 커버리지**: 플러그인이 PDF에 정의된 3가지 FD Headless operation(GENERATE_FSP / GENERATE_SDK_APP / UPDATE_SDK_APP)을 모두 지원하게 됨
- **스킬 수**: 6 → **7**, 버전 **0.4.3**
- **하위 호환**: `build-config-prop.sh`의 신규 `--app-project-path` 플래그는 optional — create-project Stage 1B(GENERATE_SDK_APP)의 기존 출력은 한 글자도 바뀌지 않음

## 이 스킬이 필요한 이유

이전에는 interface/FSP가 바뀌었을 때 유일한 옵션이 `create-project --force-clean` 뿐이었고, 이는 app skeleton을 통째로 재생성하여 사용자 커스텀 코드를 덮어썼다. Bosch의 UPDATE_SDK_APP은 FSP를 그대로 읽고 **SDK hook + skeleton 배선만** 기존 app 프로젝트에 머지하는 동작이라 user code를 보존할 수 있다. 이 PR이 그 경로를 노출한다.

## 핵심 변경

### 신규 (`skills/regen-sdk-app/`)
| 파일 | 역할 |
|------|------|
| `SKILL.md` (142L) | 트리거("SDK 재생성", "skeleton 갱신", "FSP 바뀌었는데 앱에 반영", "regen sdk", ...), When to Use 표(vs create-project/update-app/force-clean), Flow, Exit codes |
| `scripts/regen-sdk-app.sh` (290L) | `find_user_root` + `.seamos-context.json` 읽기 + `build-config-prop.sh` 델리게이트 + docker UPDATE_SDK_APP + context upsert. `--dry-run`으로 10개 경로 변수 + docker cmd 노출 |
| `evals/evals.json` | 3 prompts (happy path / missing context / interface-change routing) + assertions |
| `evals/smoke.sh` | Docker-free 19 assertions (A: missing context→64, B: partial context→64 with field list, C: full context→0 with all path vars, D: subdir upward search, E: build-config-prop 양방향 회귀) |

### 수정 (backward-compatible)
- **`skills/create-project/scripts/build-config-prop.sh`**: `--app-project-path` optional 플래그 추가. 주면 `app.project.path=<value>` 한 줄 추가(UPDATE 포맷), 안 주면 GENERATE 포맷 그대로. create-project Stage 1B 영향 없음을 회귀 테스트로 확인
- **`skills/shared-references/seamos-context-cache.md`**: schema에 `sdk_app_updated_at` 필드 추가. field ownership 표에 regen-sdk-app 행. `sdk_app_completed_at`(최초 Stage 1B 완료)은 re-run 시 **보존** — 새 `_updated_at`가 누적 refresh
- **`skills/create-project/references/local-e2e-checklist.md`**: U7 추가(실 Docker 환경에서 regen-sdk-app 검증), FAST_CHECK 섹션에 regen smoke 병기
- **`README.md`**: 배지 `skills-6→7`, `version-0.4.2→0.4.3`. regen-sdk-app 섹션 + Skill comparison 표 행 추가
- **`CLAUDE.md`**: AI Dev Pipeline 표에 Phase 1b (SDK/APP Refresh) 삽입
- **`.claude-plugin/plugin.json`**: version `0.4.2 → 0.4.3`

## 계약 요약

| 항목 | 값 |
|------|-----|
| Docker env | `FD_OPERATION=UPDATE_SDK_APP` (entrypoint.sh가 이미 지원하는 branch) |
| config.prop | GENERATE 포맷 + `app.project.path=/workspace/<PROJ>/<PROJ>_<APP>` 1줄 추가(PDF §4) |
| Context 쓰기 | `operation=UPDATE_SDK_APP`, `sdk_app_updated_at` 갱신, `sdk_app_completed_at` 보존 |
| Image | `seamos-fd-headless:0.4.2` 기본값 (override 가능) |
| Exit codes | 0/1/2/3/64/69 (Stage 1B와 통일) |

## Interface 변경은 의도적으로 거부

사용자가 interface.json을 고친 뒤 이 스킬을 부르면, UPDATE_SDK_APP 혼자서는 FSP 변경을 반영할 수 없다(Bosch 계약상 FSP를 as-is로 읽음). 그래서 `regen-sdk-app`는 이 시나리오를 묵시적으로 처리하지 않고, **`create-project --force-clean` → `regen-sdk-app`** 2-step recipe를 명시적으로 안내한다. Single Responsibility 유지 + 사용자가 app 코드 스냅샷 찍을 기회 확보.

## Verification

- `bash -n` 통과: `regen-sdk-app.sh`, `smoke.sh`, `build-config-prop.sh`
- `skills/regen-sdk-app/evals/smoke.sh` → **19 assertions PASS**
- `skills/create-project/evals/smoke.sh` → **PASS** (build-config-prop 회귀 없음 확인)

## Test plan

- [x] Docker-free smoke 19/19 PASS
- [x] build-config-prop backward compat 회귀 확인 (GENERATE 출력 불변)
- [ ] **실 Docker U1→U2→U7 E2E** — 로컬 환경에서 수동 검증 필요. 본 PR 환경에선 `public.ecr.aws/g0j5z0m9/seamos-fd-headless:0.4.2` pull이 403 Forbidden(v0.4.2의 기존 follow-up: 해당 태그 ECR publish 필요)이라 CI/로컬 둘 다 미수행
- [ ] `docker manifest inspect public.ecr.aws/g0j5z0m9/seamos-fd-headless:0.4.2` 성공 확인 (v0.4.2 follow-up 그대로 이월)
- [ ] Description triggering 최적화(`run_loop.py`) — `update-app`와의 이름 유사성 리스크 있음. 후속 작업으로 보류

🤖 Generated with [Claude Code](https://claude.com/claude-code)