### PR TITLE
feat: v0.4.4 — seamos-customui-client 스킬 추가

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ concept
 upload-app-workspace/*
 update-app-workspace/*
 manage-device-app-workspace/*
+skills/*-workspace/
 
 ref
 docker/fd-headless/prototype/*.log

--- a/skills/seamos-app-framework/references/usage-patterns/cpp.md
+++ b/skills/seamos-app-framework/references/usage-patterns/cpp.md
@@ -101,6 +101,9 @@ wsEndpoint->setMainController(getMainController());
 customui::UIWebServiceProvider::getInstance()->registerWebsocketRoute("/socket", wsEndpoint);
 ```
 
+> Browser-side counterpart (port discovery, frame protocol, cloud proxy):
+> see the `seamos-customui-client` skill.
+
 ## DB Persistence
 
 > **Note:** NEVONEX apps run in runc containers with ephemeral filesystems. App updates destroy all container-internal files. Use `FileProvider` to persist DB files to a host-mounted path that survives container restarts.

--- a/skills/seamos-app-framework/references/usage-patterns/java.md
+++ b/skills/seamos-app-framework/references/usage-patterns/java.md
@@ -93,6 +93,9 @@ public class UIWebsocketEndPoint extends AbstractWebsocketEndPoint {
 UIWebServiceProvider.getInstance().openWebsocket("/socket", UIWebsocketEndPoint.getInstance());
 ```
 
+> Browser-side counterpart (port discovery, frame protocol, cloud proxy):
+> see the `seamos-customui-client` skill.
+
 ## DB Persistence
 
 > **Note:** NEVONEX apps run in runc containers with ephemeral filesystems. App updates destroy all container-internal files. Use `FCALFileProvider` to persist DB files to a host-mounted path that survives container restarts.

--- a/skills/seamos-customui-client/SKILL.md
+++ b/skills/seamos-customui-client/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: seamos-customui-client
+description: >
+  SeamOS apps serve their CustomUI through a per-feature reverse proxy with
+  a dynamically assigned WebSocket port. Browser code that ignores this
+  produces silently broken output on every device — 404s on absolute paths,
+  hardcoded port failures, malformed WS frames, CORS errors on cloud APIs.
+  Use this skill for any HTML/JS that lives inside a SeamOS app's UI surface
+  (monitor pages, control buttons, topic streams, charts, WS publishes,
+  marketplace/cloud API calls) — even when the user frames it as a generic
+  web problem like "fetch 404", "WS not connecting", "CORS blocked", or
+  "how do I read this stream in the browser". Covers `get_assigned_ports`
+  port discovery, the four-frame WS protocol (publish / publish_ack /
+  topic / external_api_response), payload.PL parsing, and the
+  correlation-id cloud-proxy envelope for external HTTPS. Trigger
+  generously: under-triggering this skill produces code that compiles
+  fine and breaks on every real device.
+---
+
+# SeamOS CustomUI Client
+
+Browser-side companion to `seamos-app-framework`. The app's Java/C++ side
+opens a WebSocket at `/socket` (see that skill); this skill is everything the
+HTML/JS inside CustomUI needs to **find that socket, talk to it, and proxy
+external HTTPS through it**.
+
+## Why this exists (the one thing that surprises everyone)
+
+Each app gets a **dynamically assigned external port** at runtime, and the
+device's FIF web server **reverse-proxies the UI under a per-feature prefix
+like `/{featureId}/...`**. Two consequences flow from this and they trip up
+every first-time author:
+
+1. The port is not known at build time → the UI must ask for it via a
+   `get_assigned_ports` HTTP call before opening the WebSocket.
+2. That HTTP call **must use a relative URL** (`get_assigned_ports`, no
+   leading slash). A leading slash escapes the `/{featureId}/` prefix and
+   the request 404s.
+
+Once you have the external port, the WebSocket goes straight to it —
+`ws://${location.hostname}:${wsPort}/socket` — bypassing the reverse proxy.
+
+## Workflow
+
+1. **Discover the port** — `references/port-discovery.md`. Always relative
+   URL. Response values may be strings; coerce to number.
+2. **Open the WebSocket** to `ws://<host>:<port>/socket`.
+3. **Speak the frame protocol** — `references/ws-protocol.md`. Four frame
+   shapes: outgoing `publish`, incoming `publish_ack`, incoming `topic`,
+   incoming `external_api_response`.
+4. **(Optional) Proxy external HTTPS** through the WS using the cloud-proxy
+   envelope — `references/cloud-proxy.md`. Required when the UI needs to
+   call marketplace / cloud APIs that the browser can't reach directly.
+5. When in doubt, read `references/full-example.html` — a complete, working
+   monitor/control page that exercises every frame type.
+
+## Pattern selection
+
+| Task | Read |
+|------|------|
+| First-time CustomUI scaffold | port-discovery.md → ws-protocol.md → full-example.html |
+| "Show topic X live in the UI" | ws-protocol.md (incoming `topic` shape) |
+| "Add a button that toggles interface Y" | ws-protocol.md (outgoing `publish`) |
+| "UI needs to hit marketplace / cloud API" | cloud-proxy.md |
+| "Why does my fetch get 404?" | port-discovery.md (relative URL gotcha) |
+
+## Hard rules
+
+- **Relative URL for `get_assigned_ports`.** Never `/get_assigned_ports`.
+- **Coerce port to number.** The map's value is typically a string
+  (`{"1456": "59449"}`). Use `Number.parseInt(String(raw), 10)` and validate
+  with `Number.isFinite`.
+- **Check `ws.readyState === WebSocket.OPEN`** before every `ws.send`. The
+  socket closes silently when the app restarts; sending into a closed socket
+  throws.
+- **Generate a unique `correlation-id` per external API request** and keep a
+  pending-map keyed by it. Cloud responses arrive out of order.
+- **Write paths into `location.hostname` only** — never hardcode IPs. The
+  same UI bundle ships to every device.
+
+## Cross-references
+
+- Server side (Java/C++ WebSocket endpoint at `/socket`):
+  `seamos-app-framework` → WebSocket section.
+- Interface registration (the `interface` field used in `publish` frames is
+  the FD-generated interface path, e.g. `Implement.setAllSectionValveOpen`):
+  `seamos-plugins` → interface JSON synthesis.

--- a/skills/seamos-customui-client/references/cloud-proxy.md
+++ b/skills/seamos-customui-client/references/cloud-proxy.md
@@ -1,0 +1,126 @@
+# Cloud Proxy (External HTTPS via WebSocket)
+
+The browser inside CustomUI often can't reach external HTTPS endpoints
+directly — CORS, mixed-content rules, and the device's network policy all
+get in the way. The app's Java/C++ side ships a proxy
+(`CloudDownloadListenerImpl`) that takes a request envelope over the WS,
+makes the HTTPS call from the device, and returns the response over the
+same WS.
+
+This is the right tool for: marketplace login, fetching cloud-side config,
+posting telemetry to a SaaS endpoint, anything where the URL is not
+`location.hostname`.
+
+## Outgoing envelope
+
+```json
+{
+  "correlation-id": "UI-1735000000000-1",
+  "endPoint": "https://dev.marketplace-api.seamos.io/auth/login",
+  "methodSelect": "POST",
+  "reqHeader": { "Content-Type": "application/json" },
+  "reqBody": { "email": "agmo@agmo.farm", "password": "..." }
+}
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `correlation-id` | string | `"UI-${Date.now()}-${counter}"` | **Required and unique.** The UI uses it to match the response back to the originating request. Anything unique per-request works; the timestamp+counter pattern guarantees uniqueness even within the same millisecond. |
+| `endPoint` | string | `""` | Full HTTPS URL. The app forwards verbatim. |
+| `methodSelect` | string | `"GET"` | HTTP verb. Common values: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. |
+| `reqHeader` | object | `{}` | Headers as a flat JSON object. Empty `{}` is valid — include the field even when empty so the envelope shape is stable. |
+| `reqBody` | object | `{}` | Request body. The app serialises this as JSON. For `GET`/`DELETE` an empty `{}` is fine. |
+
+The proxy does not auto-add a `Content-Type` — set it explicitly in
+`reqHeader` for any request with a body.
+
+## Incoming envelope
+
+```json
+{
+  "type": "external_api_response",
+  "correlation-id": "UI-1735000000000-1",
+  "data": { "...upstream response body, already parsed..." }
+}
+```
+
+`data` is the upstream response body **already JSON-parsed** by the app —
+the UI does not need to `JSON.parse` it again.
+
+## Correlation-id lifecycle
+
+Cloud calls can take seconds; the user can fire several before the first
+one returns. Out-of-order responses are normal. Keep a pending-map keyed
+by id:
+
+```js
+const pendingReqs = new Map()  // correlation-id → { resolve, reject, timeoutHandle }
+let counter = 0
+
+function callCloud(ws, { url, method = 'GET', headers = {}, body = {} }) {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      reject(new Error('ws not open'))
+      return
+    }
+    counter += 1
+    const cid = `UI-${Date.now()}-${counter}`
+    const timeoutHandle = setTimeout(() => {
+      pendingReqs.delete(cid)
+      reject(new Error(`cloud request timed out: cid=${cid}`))
+    }, 30_000)
+    pendingReqs.set(cid, { resolve, reject, timeoutHandle })
+    ws.send(JSON.stringify({
+      'correlation-id': cid,
+      endPoint: url,
+      methodSelect: method,
+      reqHeader: headers,
+      reqBody: body,
+    }))
+  })
+}
+
+// In the WS message dispatcher (see ws-protocol.md):
+function handleApiResponse(frame) {
+  const cid = frame['correlation-id']
+  const pending = pendingReqs.get(cid)
+  if (!pending) {
+    // Orphan — request was cancelled, or duplicate response. Log and drop.
+    return
+  }
+  clearTimeout(pending.timeoutHandle)
+  pendingReqs.delete(cid)
+  pending.resolve(frame.data)
+}
+```
+
+## Why `correlation-id` and not just request order?
+
+The WebSocket itself preserves order, but the proxy on the app side may
+finish requests out of order (one slow upstream blocks behind a faster
+later one). Pairing by id is the only reliable scheme.
+
+## Failure modes worth handling
+
+| Symptom | Cause / fix |
+|---------|------------|
+| Response never arrives | Upstream hung or app-side proxy busy. The `setTimeout` reject path is required, not optional. |
+| Orphan response in handler | UI cancelled but the request still fired — drop silently after logging. |
+| `data` is a string, not an object | Upstream returned non-JSON. The app passes it through as-is; handle the string branch. |
+| Duplicate `correlation-id` | Counter not advanced or two UIs sharing one id space. Always include `Date.now()` *and* the counter. |
+
+## Pattern: minimal usage
+
+```js
+try {
+  const userInfo = await callCloud(ws, {
+    url: 'https://dev.marketplace-api.seamos.io/auth/me',
+    method: 'GET',
+    headers: { 'Authorization': `Bearer ${token}` },
+    // body omitted — defaults to {}, harmless for GET
+  })
+  renderUser(userInfo)
+} catch (err) {
+  showError(err.message)
+}
+```

--- a/skills/seamos-customui-client/references/full-example.html
+++ b/skills/seamos-customui-client/references/full-example.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>CustomUI Signal Monitor</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 1rem; color: #222; }
+    h1 { font-size: 1.2rem; margin: 0 0 .5rem; }
+    #status { display: inline-block; padding: 3px 10px; border-radius: 4px; background: #eee; font-size: .85rem; }
+    #status[data-state="open"] { background: #cfe9cf; }
+    #status[data-state="closed"] { background: #f5c7c7; }
+    #status[data-state="error"] { background: #f5c7c7; }
+    #topics { margin-top: 1rem; display: grid; gap: 6px; }
+    .topic-row { padding: 6px 10px; border: 1px solid #ccc; border-radius: 4px; font-family: ui-monospace, monospace; font-size: .85rem; display: grid; grid-template-columns: 180px 1fr auto; gap: 10px; align-items: center; }
+    .topic-row[data-live="true"] { background: #eafaea; border-color: #7cb97c; }
+    .topic-name { font-weight: 600; }
+    .topic-count { color: #666; font-size: .75rem; }
+    .topic-values { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .api-panel { margin: .8rem 0; padding: 10px 12px; border: 1px solid #9bb; border-radius: 6px; background: #f0f8f8; }
+    .api-panel h2 { font-size: 1rem; margin: 0 0 .5rem; }
+    .api-row { display: grid; grid-template-columns: 120px 1fr; gap: 8px; align-items: center; margin-bottom: 6px; }
+    .api-row label { font-size: .85rem; color: #444; }
+    .api-row input, .api-row select, .api-row textarea { font: inherit; padding: 4px 6px; border: 1px solid #bbb; border-radius: 3px; width: 100%; box-sizing: border-box; }
+    .api-row textarea { font-family: ui-monospace, monospace; font-size: .8rem; min-height: 48px; resize: vertical; }
+    .api-actions { display: flex; gap: 8px; align-items: center; margin-top: 6px; }
+    .api-actions button { padding: 4px 16px; cursor: pointer; }
+    .api-log { margin-top: 8px; max-height: 240px; overflow-y: auto; font-family: ui-monospace, monospace; font-size: .78rem; background: #fff; border: 1px solid #ddd; border-radius: 3px; padding: 6px; }
+    .api-entry { padding: 4px 6px; border-bottom: 1px solid #eee; }
+    .api-entry.pending { color: #888; }
+    .api-entry.done { color: #2a6a2a; }
+    .api-entry.failed { color: #a02525; }
+    .api-entry pre { margin: 2px 0 0 0; white-space: pre-wrap; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <h1>CustomUI Signal Monitor</h1>
+  <span id="status" data-state="init">initializing…</span>
+
+  <div style="margin: .8rem 0; padding: 8px 12px; border: 1px solid #aac; border-radius: 6px; background: #f0f4ff;">
+    <strong>Publish Test — SetAllSectionValveOpen</strong>
+    <button id="pub-btn" style="margin-left: 10px; padding: 4px 16px; cursor: pointer;">Toggle OFF → ON</button>
+    <span id="pub-state" style="margin-left: 8px; font-weight: 600;">state: OFF</span>
+    <span id="pub-count" style="margin-left: 8px; color: #666; font-size: .85rem;"></span>
+    <div id="pub-log" style="margin-top: 4px; font-family: monospace; font-size: .8rem; color: #444; max-height: 80px; overflow-y: auto;"></div>
+  </div>
+
+  <div class="api-panel">
+    <h2>External API Request (Cloud proxy)</h2>
+    <div class="api-row">
+      <label for="api-url">URL</label>
+      <input id="api-url" type="text" placeholder="https://dev.marketplace-api.seamos.io/auth/login">
+    </div>
+    <div class="api-row">
+      <label for="api-method">Method</label>
+      <select id="api-method">
+        <option>GET</option><option selected>POST</option><option>PUT</option><option>PATCH</option><option>DELETE</option>
+      </select>
+    </div>
+    <div class="api-row">
+      <label for="api-headers">Headers (JSON)</label>
+      <textarea id="api-headers" placeholder='{"Content-Type":"application/json"}'>{"Content-Type":"application/json"}</textarea>
+    </div>
+    <div class="api-row">
+      <label for="api-body">Body (JSON)</label>
+      <textarea id="api-body" placeholder='{"email":"agmo@agmo.farm","password":"..."}'></textarea>
+    </div>
+    <div class="api-actions">
+      <button id="api-send">Send Request</button>
+      <button id="api-clear" type="button">Clear Log</button>
+      <span id="api-status" style="font-size: .8rem; color: #666;"></span>
+    </div>
+    <div class="api-log" id="api-log"></div>
+  </div>
+
+  <div id="topics"></div>
+
+  <script>
+    (async () => {
+      const statusEl = document.getElementById('status')
+      const topicsEl = document.getElementById('topics')
+      const rows = new Map()
+
+      function setStatus(text, state) {
+        statusEl.textContent = text
+        statusEl.dataset.state = state
+      }
+
+      // 1) 할당 포트 조회 — device FIF server reverse-proxies under /{featureId}/...
+      // so request must be RELATIVE (not '/get_assigned_ports') to preserve the
+      // prefix. Response: { "<internal_port>": "<external_port>" } where values
+      // are STRINGS (e.g. {"1456": "59449"}). Both strings and numbers accepted.
+      let wsPort
+      try {
+        setStatus('fetching get_assigned_ports…', 'init')
+        const res = await fetch('get_assigned_ports', { cache: 'no-store' })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const ports = await res.json()
+        const raw = Object.values(ports)[0]
+        const parsed = typeof raw === 'number' ? raw : Number.parseInt(String(raw), 10)
+        if (!Number.isFinite(parsed)) throw new Error(`unexpected payload: ${JSON.stringify(ports)}`)
+        wsPort = parsed
+      } catch (e) {
+        setStatus(`port lookup failed: ${e.message}`, 'error')
+        return
+      }
+
+      // 2) WebSocket 연결
+      const wsUrl = `ws://${location.hostname}:${wsPort}/socket`
+      setStatus(`connecting ${wsUrl}…`, 'init')
+      const ws = new WebSocket(wsUrl)
+      ws.addEventListener('open', () => setStatus(`open ${wsUrl}`, 'open'))
+      ws.addEventListener('close', () => setStatus('ws closed', 'closed'))
+      ws.addEventListener('error', () => setStatus('ws error', 'error'))
+
+      // 2b) Publish 토글 버튼 — SetAllSectionValveOpen (BOOLEAN)
+      let pubCount = 0
+      let pubState = false
+      const pubBtn = document.getElementById('pub-btn')
+      const pubStateEl = document.getElementById('pub-state')
+      const pubCountEl = document.getElementById('pub-count')
+      const pubLog = document.getElementById('pub-log')
+      function renderPubState() {
+        pubStateEl.textContent = `state: ${pubState ? 'ON' : 'OFF'}`
+        pubBtn.textContent = pubState ? 'Toggle ON → OFF' : 'Toggle OFF → ON'
+      }
+      renderPubState()
+      pubBtn.addEventListener('click', () => {
+        if (ws.readyState !== WebSocket.OPEN) return
+        pubState = !pubState
+        ws.send(JSON.stringify({
+          action: 'publish',
+          interface: 'Implement.setAllSectionValveOpen',
+          value: pubState,
+        }))
+        renderPubState()
+      })
+
+      // 2c) External API Request 패널
+      const apiUrl = document.getElementById('api-url')
+      const apiMethod = document.getElementById('api-method')
+      const apiHeaders = document.getElementById('api-headers')
+      const apiBody = document.getElementById('api-body')
+      const apiSend = document.getElementById('api-send')
+      const apiClear = document.getElementById('api-clear')
+      const apiStatus = document.getElementById('api-status')
+      const apiLog = document.getElementById('api-log')
+      const pendingReqs = new Map() // correlation-id → log DOM entry
+      let apiCounter = 0
+
+      function parseJsonField(raw, fallback) {
+        const v = (raw || '').trim()
+        if (!v) return fallback
+        try { return JSON.parse(v) } catch { return null }
+      }
+
+      apiSend.addEventListener('click', () => {
+        if (ws.readyState !== WebSocket.OPEN) { apiStatus.textContent = 'ws not open'; return }
+        const url = (apiUrl.value || '').trim()
+        if (!url) { apiStatus.textContent = 'URL required'; return }
+        const headers = parseJsonField(apiHeaders.value, {})
+        if (headers === null) { apiStatus.textContent = 'Headers: invalid JSON'; return }
+        const body = parseJsonField(apiBody.value, {})
+        if (body === null) { apiStatus.textContent = 'Body: invalid JSON'; return }
+
+        apiCounter += 1
+        const cid = `UI-${Date.now()}-${apiCounter}`
+        const payload = {
+          'correlation-id': cid,
+          endPoint: url,
+          methodSelect: apiMethod.value,
+          reqHeader: headers,
+          reqBody: body,
+        }
+
+        const entry = document.createElement('div')
+        entry.className = 'api-entry pending'
+        entry.innerHTML = `<div><strong>[${new Date().toLocaleTimeString()}]</strong> ${apiMethod.value} ${url} <em>(cid=${cid})</em></div><pre>pending…</pre>`
+        apiLog.prepend(entry)
+        pendingReqs.set(cid, entry)
+
+        ws.send(JSON.stringify(payload))
+        apiStatus.textContent = `sent cid=${cid}`
+      })
+
+      apiClear.addEventListener('click', () => { apiLog.innerHTML = ''; pendingReqs.clear() })
+
+      // 3) 프레임 수신 → topic 별 row 업데이트 (가벼운 시각화)
+      ws.addEventListener('message', ev => {
+        let frame
+        try { frame = JSON.parse(ev.data) } catch { return }
+
+        // External API response 처리 (CloudDownloadListenerImpl envelope)
+        if (frame.type === 'external_api_response') {
+          const cid = frame['correlation-id'] || ''
+          const entry = pendingReqs.get(cid)
+          const pretty = JSON.stringify(frame.data, null, 2)
+          if (entry) {
+            entry.classList.remove('pending'); entry.classList.add('done')
+            entry.querySelector('pre').textContent = pretty
+            pendingReqs.delete(cid)
+          } else {
+            const orphan = document.createElement('div')
+            orphan.className = 'api-entry done'
+            orphan.innerHTML = `<div><strong>[${new Date().toLocaleTimeString()}]</strong> ← response <em>(cid=${cid || 'unknown'})</em></div><pre></pre>`
+            orphan.querySelector('pre').textContent = pretty
+            apiLog.prepend(orphan)
+          }
+          return
+        }
+
+        // Publish ack 처리
+        if (frame.action === 'publish_ack') {
+          pubCount++
+          pubCountEl.textContent = `sent: ${pubCount}`
+          const line = document.createElement('div')
+          line.textContent = `[${new Date().toLocaleTimeString()}] -> ${frame.topic} (${frame.status})`
+          pubLog.prepend(line)
+          return
+        }
+
+        const topic = frame && frame.topic
+        if (!topic) return
+        let row = rows.get(topic)
+        if (!row) {
+          row = document.createElement('div')
+          row.className = 'topic-row'
+          row.dataset.topic = topic
+          row.id = `topic-${topic.replace(/[^a-zA-Z0-9_-]/g, '_')}`
+          row.innerHTML = '<span class="topic-name"></span><span class="topic-values"></span><span class="topic-count"></span>'
+          topicsEl.appendChild(row)
+          rows.set(topic, { el: row, count: 0 })
+        }
+        const entry = rows.get(topic)
+        entry.count += 1
+        entry.el.dataset.live = 'true'
+        entry.el.querySelector('.topic-name').textContent = topic
+        entry.el.querySelector('.topic-count').textContent = `#${entry.count}`
+
+        // payload.PL 안의 첫 배열 미리보기 (최대 6 값)
+        let preview = ''
+        try {
+          const pl = frame.payload && frame.payload.PL
+          if (pl && typeof pl === 'object') {
+            const arrEntry = Object.values(pl).find(v => v && typeof v === 'object' && Array.isArray(v['0']))
+            if (arrEntry) preview = arrEntry['0'].slice(0, 6).map(v => typeof v === 'number' ? v.toFixed(2) : String(v)).join(', ')
+          }
+        } catch { /* ignore */ }
+        entry.el.querySelector('.topic-values').textContent = preview
+      })
+    })()
+  </script>
+</body>
+</html>

--- a/skills/seamos-customui-client/references/port-discovery.md
+++ b/skills/seamos-customui-client/references/port-discovery.md
@@ -1,0 +1,104 @@
+# Port Discovery
+
+The dynamically assigned external port for the app's WebSocket is fetched
+from the device's FIF web server via a per-feature endpoint named
+`get_assigned_ports`.
+
+## The endpoint
+
+```
+GET get_assigned_ports
+```
+
+**Relative URL — no leading slash.** The device exposes the UI under
+`/{featureId}/...` and reverse-proxies anything below that prefix into the
+app. A leading slash escapes the prefix and the request 404s. Authors who
+copy-paste from generic JS examples (`fetch('/api/...')`) hit this
+immediately.
+
+```js
+// CORRECT
+const res = await fetch('get_assigned_ports', { cache: 'no-store' })
+
+// WRONG — escapes /{featureId}/ prefix, 404
+const res = await fetch('/get_assigned_ports')
+```
+
+`cache: 'no-store'` matters because the port can change across app restarts;
+a stale cached response would point at a dead port.
+
+## Response shape
+
+```json
+{ "<internal_port>": "<external_port>" }
+```
+
+Single-entry map. Keys and values are typically **strings** even though they
+look like numbers. Real-world example:
+
+```json
+{ "1456": "59449" }
+```
+
+- `1456` — the in-container port the app's WS server bound to
+- `59449` — the host-side port the device exposes externally
+
+The UI only cares about the value (external port).
+
+## Parsing
+
+Coerce defensively — accept both string and number, validate finite:
+
+```js
+const ports = await res.json()
+const raw = Object.values(ports)[0]
+const parsed = typeof raw === 'number' ? raw : Number.parseInt(String(raw), 10)
+if (!Number.isFinite(parsed)) {
+  throw new Error(`unexpected payload: ${JSON.stringify(ports)}`)
+}
+const wsPort = parsed
+```
+
+## Building the WebSocket URL
+
+The WebSocket connects directly to the external port — it does **not** go
+through the `/{featureId}/` reverse proxy.
+
+```js
+const wsUrl = `ws://${location.hostname}:${wsPort}/socket`
+```
+
+- `location.hostname` — never hardcode an IP. The UI bundle ships to every
+  device and `location.hostname` is whatever the user typed in the browser.
+- `/socket` — the path the app's Java/C++ side registered with
+  `UIWebServiceProvider.openWebsocket("/socket", ...)` /
+  `registerWebsocketRoute("/socket", ...)`. If the server side uses a
+  different path, mirror it here.
+- `ws://` (not `wss://`) — the device serves plain WS on the LAN. If the
+  page itself loads over `https://`, mixed-content rules will block this;
+  serve the UI over `http://` to match.
+
+## Failure modes worth handling
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `fetch` returns 404 | Used `/get_assigned_ports` (absolute). Drop the slash. |
+| `fetch` returns empty `{}` | App not started yet, or feature ID prefix wrong. Retry after a beat. |
+| `Number.isFinite` false | Response shape changed. Log the raw payload before throwing. |
+| WS `error` immediately | Wrong port (e.g. you grabbed the *internal* one — use `Object.values`, not `Object.keys`). |
+
+## Pattern
+
+```js
+async function discoverWsUrl() {
+  const res = await fetch('get_assigned_ports', { cache: 'no-store' })
+  if (!res.ok) throw new Error(`get_assigned_ports HTTP ${res.status}`)
+  const ports = await res.json()
+  const raw = Object.values(ports)[0]
+  const port = typeof raw === 'number' ? raw : Number.parseInt(String(raw), 10)
+  if (!Number.isFinite(port)) {
+    throw new Error(`bad get_assigned_ports payload: ${JSON.stringify(ports)}`)
+  }
+  return `ws://${location.hostname}:${port}/socket`
+}
+```

--- a/skills/seamos-customui-client/references/ws-protocol.md
+++ b/skills/seamos-customui-client/references/ws-protocol.md
@@ -1,0 +1,151 @@
+# WebSocket Frame Protocol
+
+After the WebSocket opens at `ws://<host>:<port>/socket`, four frame shapes
+are in play. The UI sends one (`publish`) and receives three (`publish_ack`,
+topic frames, and `external_api_response`).
+
+All frames are JSON text. There is no length prefix or framing beyond what
+the WebSocket layer provides.
+
+## Outgoing: `publish`
+
+Used to set the value of an FD-defined interface — buttons, toggles,
+sliders, anything user-driven.
+
+```json
+{
+  "action": "publish",
+  "interface": "Implement.setAllSectionValveOpen",
+  "value": true
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `action` | string | Always `"publish"` for outgoing control frames. |
+| `interface` | string | The FD interface path. Same string the FSP/SDK uses (e.g. `Implement.setAllSectionValveOpen`, `Sense.getCurrentSpeed`). Browse via `seamos-plugins`. |
+| `value` | depends on interface type | Boolean / number / string / array, matching the interface's declared type. |
+
+**Always guard with readyState** — sending into a closing socket throws:
+
+```js
+function publish(ws, interfaceName, value) {
+  if (ws.readyState !== WebSocket.OPEN) return false
+  ws.send(JSON.stringify({ action: 'publish', interface: interfaceName, value }))
+  return true
+}
+```
+
+## Incoming: `publish_ack`
+
+Server-side confirmation that a `publish` was accepted (or rejected).
+
+```json
+{
+  "action": "publish_ack",
+  "topic": "Implement.setAllSectionValveOpen",
+  "status": "ok"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `action` | string | `"publish_ack"`. |
+| `topic` | string | Echo of the interface that was published to. |
+| `status` | string | `"ok"` on success; otherwise an error string from the app. |
+
+Use this for UI feedback (toast, log line, button-state confirmation). It's
+not strictly required to consume it — the UI can fire-and-forget — but
+showing acks helps users notice when the app side is unresponsive.
+
+## Incoming: topic frame (sensor / state stream)
+
+Anything the app is broadcasting on its own initiative — sensor reads,
+periodic state, computed values. There is no "subscribe" handshake; the
+app pushes whatever it's configured to push.
+
+```json
+{
+  "topic": "Sense.boomSectionFlow",
+  "payload": {
+    "PL": {
+      "<some-key>": { "0": [12.3, 12.5, 12.7, 12.4, 12.6, 12.5] }
+    }
+  }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `topic` | string | The interface name being broadcast. |
+| `payload.PL` | object | Payload container. The inner shape varies by interface type. |
+
+**Recognising the frame:** check `frame.topic` exists. If yes and it's not
+a `publish_ack` (no `action` field), treat it as a topic frame.
+
+**Extracting array previews** — common case is a plot-friendly numeric
+array under `payload.PL.<key>['0']`:
+
+```js
+function previewArray(frame, max = 6) {
+  const pl = frame?.payload?.PL
+  if (!pl || typeof pl !== 'object') return ''
+  const arrEntry = Object.values(pl).find(
+    v => v && typeof v === 'object' && Array.isArray(v['0']),
+  )
+  if (!arrEntry) return ''
+  return arrEntry['0']
+    .slice(0, max)
+    .map(v => typeof v === 'number' ? v.toFixed(2) : String(v))
+    .join(', ')
+}
+```
+
+For non-array payloads (scalars, structs), inspect `payload.PL` directly —
+the FD-generated interface metadata documents the exact shape per topic.
+
+## Incoming: `external_api_response`
+
+Reply envelope for cloud-proxy requests. See `cloud-proxy.md` for the
+matching outgoing envelope and full correlation-id flow.
+
+```json
+{
+  "type": "external_api_response",
+  "correlation-id": "UI-1735000000000-1",
+  "data": { "...whatever the upstream API returned..." }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | string | `"external_api_response"`. Distinguishes it from topic frames (which have `topic`, not `type`). |
+| `correlation-id` | string | Echo of the id the UI sent. Match against the pending-map. |
+| `data` | any | The upstream response body, already JSON-parsed by the app. |
+
+## Dispatch skeleton
+
+```js
+ws.addEventListener('message', ev => {
+  let frame
+  try { frame = JSON.parse(ev.data) } catch { return }
+
+  if (frame.type === 'external_api_response') {
+    handleApiResponse(frame)         // see cloud-proxy.md
+    return
+  }
+  if (frame.action === 'publish_ack') {
+    handlePublishAck(frame)
+    return
+  }
+  if (frame.topic) {
+    handleTopic(frame)
+    return
+  }
+  // Unknown frame — log for debugging
+})
+```
+
+Order matters: `external_api_response` and `publish_ack` are both
+distinguished by a unique top-level field; check those before falling
+through to the generic `topic` branch.


### PR DESCRIPTION
## Summary

- SeamOS app **CustomUI 브라우저 측 가이드**를 새 스킬 `seamos-customui-client`로 분리. 기존 `seamos-app-framework`는 서버 측(Java/C++) WS 등록만 다루고 있었음
- 핵심 함정 셋: ① `get_assigned_ports`는 **상대 URL** 필수 (FIF reverse-proxy `/{featureId}/...` prefix 보존), ② 응답 값이 string일 수 있어 coerce 필요, ③ cloud proxy는 `correlation-id` 매칭 필수
- 4-frame WS 프로토콜(`publish` / `publish_ack` / `topic` / `external_api_response`)과 cloud-proxy envelope 전 필드 문서화

## What's new

- `skills/seamos-customui-client/SKILL.md` — 워크플로 + hard rules + 패턴 선택
- `references/port-discovery.md` — 상대 URL 함정, 응답 파싱, 실패 모드
- `references/ws-protocol.md` — 4 frame 종, dispatch skeleton, payload.PL 추출
- `references/cloud-proxy.md` — correlation-id 라이프사이클, Promise 래퍼 + timeout
- `references/full-example.html` — 동작하는 monitor/control 예시 페이지
- `seamos-app-framework`(java.md, cpp.md) WS 섹션에 cross-reference 한 줄 추가
- `skills/*-workspace/` .gitignore 패턴 (skill-creator workspace 보존용)

## Trigger description optimization

`skill-creator`의 description optimization 1차 측정 + 수동 압축형 재작성:

| Version | Precision | Recall | 길이 |
|---|---|---|---|
| v1 (긴 키워드 나열형) | 100% | ~14% | ~1700자 |
| v2 (압축 압박형) | 100% | ~13% | ~750자 |

→ false positive 0, recall은 SeamOS-specific 식별자(`setAllSectionValveOpen`, `customui/`, `correlation-id cloud proxy` 등)가 쿼리에 명시된 경우 발동. 일반 "WS 연결" / "monitor 화면" 만으론 약함 — 모델(Opus 4.7)의 self-confidence 특성이라 description 튜닝의 marginal 효과 작음. 자동 5-iter 루프는 `ANTHROPIC_API_KEY` 미설정으로 미사용 (워크스페이스 보존, 추후 재시도 가능).

## Test plan

- [ ] `/help`에서 새 스킬 노출 확인
- [ ] CustomUI HTML 작성 시 자동 발동 (예: "customui/index.html에서 get_assigned_ports 404 떠")
- [ ] cross-reference 동작 — `seamos-app-framework` WS 섹션에서 새 스킬 안내 확인
- [ ] `seamos-customui-client/references/full-example.html` 실제 디바이스에서 로드 시 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)