### PR TITLE
fix: v0.5.6 — build-fif disk 무차별 패키징 결함 + 3 경로 정책 정립

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.5.6] — 2026-04-30
+
+`build-fif` 의 disk 무차별 패키징 결함을 잡고, 빌드/regen/runtime 의 3 경로 정책(`./db/` working / `disk/<feature>/` persistent / `disk/seed/` allowlist) 을 6 개 문서에 일관 명시. `update-app` 측 fallback 휴리스틱 제거를 위한 `last_app_register` 캐시 스키마 신설(`update-app` 본 동작 변경은 v0.5.7 에서 따라옴).
+
+### Fixed — `build-fif` 매 버전 업데이트마다 디바이스 DB 가 빌드 시점 snapshot 으로 롤백
+
+build-fif.sh 의 cleanup 단계가 사용자 워크스페이스의 `disk/` 디렉토리(개발 중 쌓인 H2/SQLite 운영 데이터 포함)를 통째로 FIF 에 패키징해 디바이스에 배포되던 회귀. Java cleanup 분기는 `*.mv.db` 정도만 부분 제거했고 C++ 분기에는 대응 코드가 전무했음. 결과적으로 새 버전을 올릴 때마다 디바이스 운영 DB 가 빌드 시점 사본으로 강제 롤백되며, 시드 데이터와 우연한 dev 데이터를 구별할 방법이 없었음.
+
+- `disk_packaging_policy()` 함수 신설 — `disk/seed/` 만 allowlist 로 보존, 그 외 `disk/**` 는 빌드 임시 사본에서 제거. apply/dry-run 양쪽 지원, bash 3.2 호환, `set -e` 친화적.
+- Java/C++ cleanup 분기 양쪽에서 빌드 임시 사본 경로(`/tmp/nvx/app_proj/$(basename "$APP_PATH")`) 에 대해 호출. 사용자 원본 워크스페이스는 절대 건드리지 않음.
+- DRY-RUN 출력에 `APP_TYPE`/`APP_PATH`/`SDK_PATH`/`DISK_POLICY`/`DISK_SCAN_RESULT` 5 필드 추가 — 빌드 전에 어떤 파일이 제외/보존되는지 사전 확인 가능.
+- 산출물 캡처를 `cp ... 2>/dev/null` + `ls *.fif | head -1` 침묵 패턴에서 명시 배열 + 0 개 검출 시 `No FIF artifact produced` 에러 + 다중 FIF 모두 보고로 교체.
+
+### Added — 3 경로 정책 6 개 문서에 일관 명시
+
+`./db/` (working DB, gitignored) / `disk/<feature>/...` (persistent, 디바이스 측 생성) / `disk/seed/...` (allowlist, 빌드 시 포함, 첫 부팅 시 디바이스로 복사) 세 경로의 책임 분리를 다음 6 개 파일에 일관 명시:
+
+- `build-fif/SKILL.md` — Disk packaging policy 섹션 신설
+- `build-fif/references/build-details.md` — Disk Packaging Policy 섹션 + 표 + 디렉토리 트리 예시
+- `seamos-app-framework/SKILL.md` — Notes 에 DB path conventions 표
+- `seamos-app-framework/references/usage-patterns/java.md` — DB Persistence 헤더 직후 단락 prepend (H2 기준)
+- `seamos-app-framework/references/usage-patterns/cpp.md` — DB Persistence 헤더 직후 단락 prepend (SQLite 기준)
+- `regen-sdk-app/SKILL.md` — 보존 정책 표에 `disk/` 행 추가 (regen 은 보존 / build-fif 는 disk/seed/ 만 패키징)
+
+### Added — `last_app_register` 캐시 스키마
+
+`shared-references/seamos-context-cache.md` 에 `update-app` 의 마지막 등록 컨텍스트(`feuType`/`arch`/`appId`/`updatedAt`) 를 캐시하는 영역 신설. `update-app` 본 동작 변경(fallback 휴리스틱 제거) 은 v0.5.7 에서 따라옴.
+
+### Added — 회귀 방지 테스트
+
+- `build-fif/scripts/test/test-disk-policy.sh` — 5 개 assertion: apply mode stdout 포맷, `disk/seed/` 만 보존 검증, dry-run 포맷, dry-run 비파괴성, `disk/` 부재 시 안내 메시지.
+
 ## [0.5.3] — 2026-04-28
 
 `run-app --via-fd-cli` 와 `regen-sdk-app` 의 실전 사용 중 드러난 6종 버그/제약을 한 번에 수정. 모두 코드 변경 없이 스킬 측에서 흡수 가능한 케이스라 패치 버전 bump.

--- a/skills/build-fif/SKILL.md
+++ b/skills/build-fif/SKILL.md
@@ -21,3 +21,7 @@ The first positional argument is **USER_ROOT** (directory containing `.mcp.json`
 Map user arguments to env vars before the command: `APP_TYPE=cpp|java`, `ARCH_TYPE=aarch64|arm32|x86_64`, `NVX_DOCKER_IMAGE=<url>`. `--project-name <NAME>` flag disambiguates when multiple FSP projects live under a single USER_ROOT.
 
 Output: `$USER_ROOT/seamos-assets/builds/*.fif` — consumed directly by the upload-app skill. On error, read [build-details.md](references/build-details.md) for troubleshooting.
+
+## Disk packaging policy
+
+`disk/` 하위는 기본적으로 패키징에서 제외된다. 단 `disk/seed/` 하위는 allowlist 로 그대로 패키징된다 — 앱이 의도적으로 동봉하는 시드 데이터(초기값) 를 위한 경로다. working DB(`./db/`) 는 항상 제외되며, 디바이스 영속 영역(`disk/<feature>/...`) 은 디바이스 측에서 런타임에 생성되므로 빌드 산출물에 포함되지 않는다. 자세한 정책은 `references/build-details.md` 의 "Disk Packaging Policy" 참고.

--- a/skills/build-fif/references/build-details.md
+++ b/skills/build-fif/references/build-details.md
@@ -170,3 +170,33 @@ docker exec $CONTAINER /usr/share/build.sh \
 |---|---|---|
 | `FIF file not found` | build.sh failed | Check Docker logs: `docker logs nvx-fif-gen-cntr` |
 | Empty output directory | Container internal error | Inspect: `docker exec nvx-fif-gen-cntr ls /fif_output/` |
+
+## Disk Packaging Policy
+
+빌드 시 앱 폴더 내 디스크 관련 디렉토리는 다음 정책으로 처리된다.
+
+| 디렉토리 | 의미 | 빌드 패키징 | 런타임/regen |
+|---|---|---|---|
+| `./db/` | 빌드/런 시 작업 DB (working copy, gitignored) | 제외 | 런타임에 생성, regen 시 보존 |
+| `disk/<feature>/...` | 디바이스 영속 영역 (persistent) | **제외** | 디바이스에서 생성/유지 |
+| `disk/seed/...` | 앱이 의도적으로 동봉하는 시드 데이터 | **포함 (allowlist)** | 첫 부팅 시 디바이스로 복사 |
+
+매칭 규칙은 단순 디렉토리 prefix — `disk/seed/**` 글롭이 패키징되고 그 외 `disk/**` 는 빌드 임시 사본에서 제거된다. 사용자의 원본 워크스페이스 `disk/` 는 절대 변경되지 않는다.
+
+예시 디렉토리 트리:
+
+```
+<workspace>/<app>/
+├── db/
+│   └── working.h2.mv.db          ← 제외 (working DB)
+├── disk/
+│   ├── seed/
+│   │   └── init.json             ← 포함 (allowlist)
+│   ├── cache/
+│   │   └── foo.bin               ← 제외 (런타임 캐시)
+│   └── persistence/
+│       └── runtime.db            ← 제외 (디바이스 영속 영역)
+└── ...
+```
+
+DRY-RUN 모드 (`build-fif.sh --dry-run`) 출력의 `DISK_SCAN_RESULT` 라인에서 실제 빌드 시 어떤 파일들이 제외/보존되는지 사전에 확인할 수 있다 — `disk/seed/` 하위만 `INCLUDE` 로, 나머지 `disk/**` 는 `EXCLUDE` 로 표시된다.

--- a/skills/build-fif/scripts/build-fif.sh
+++ b/skills/build-fif/scripts/build-fif.sh
@@ -98,6 +98,69 @@ resolve_project_name() {
   return 64
 }
 
+# disk_packaging_policy — apply disk/ allowlist (keep only disk/seed/) on a build workspace copy.
+# Usage:
+#   disk_packaging_policy <APP_PATH>             # apply (rm files outside disk/seed/)
+#   disk_packaging_policy --dry-run <APP_PATH>   # count only, no deletion
+#
+# Caller MUST pass the build temp workspace copy — never the user's source workspace.
+# Always returns 0 (safe under set -e).
+disk_packaging_policy() {
+  local dry_run=0
+  if [[ "${1:-}" == "--dry-run" ]]; then
+    dry_run=1
+    shift
+  fi
+  local app_path="${1:-}"
+  local disk_dir="$app_path/disk"
+
+  if [[ ! -d "$disk_dir" ]]; then
+    echo "(no disk/ directory)"
+    return 0
+  fi
+
+  local excluded=0
+  local retained=0
+  local f
+
+  # Count + (optionally) delete files outside disk/seed/
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    excluded=$((excluded + 1))
+    if [[ $dry_run -eq 0 ]]; then
+      rm -f "$f"
+    fi
+  done < <(find "$disk_dir" -type f -not -path "$disk_dir/seed/*" 2>/dev/null)
+
+  # Count files retained under disk/seed/
+  if [[ -d "$disk_dir/seed" ]]; then
+    while IFS= read -r f; do
+      [[ -z "$f" ]] && continue
+      retained=$((retained + 1))
+    done < <(find "$disk_dir/seed" -type f 2>/dev/null)
+  fi
+
+  # Remove now-empty directories outside disk/seed/ (apply mode only)
+  if [[ $dry_run -eq 0 ]]; then
+    while IFS= read -r d; do
+      [[ -z "$d" ]] && continue
+      [[ "$d" == "$disk_dir" ]] && continue
+      [[ "$d" == "$disk_dir/seed" ]] && continue
+      case "$d" in
+        "$disk_dir/seed"/*) continue ;;
+      esac
+      rm -rf "$d"
+    done < <(find "$disk_dir" -mindepth 1 -type d -not -path "$disk_dir/seed" -not -path "$disk_dir/seed/*" 2>/dev/null)
+  fi
+
+  if [[ $dry_run -eq 1 ]]; then
+    echo "would exclude $excluded files from disk/, would retain $retained files in disk/seed/"
+  else
+    echo "Excluded $excluded files from disk/, retained $retained files in disk/seed/"
+  fi
+  return 0
+}
+
 # ─── Parse args ─────────────────────────────────────────────────────────────
 POSITIONAL_USER_ROOT=""
 PROJECT_NAME_FLAG=""
@@ -183,20 +246,6 @@ NVX_DOCKER_IMAGE="${NVX_DOCKER_IMAGE:-public.ecr.aws/g0j5z0m9/seamos/app-builder
 NVX_VERSION="${NVX_DOCKER_IMAGE##*:}"
 ARCH_TYPE="${ARCH_TYPE:-aarch64}"
 BUILD_DIR="$USER_ROOT/seamos-assets/builds"
-
-# ─── Dry-run output (v4 CIMP-4: expose key paths) ──────────────────────────
-if [[ $DRY_RUN -eq 1 ]]; then
-  echo "[dry-run] USER_ROOT=$USER_ROOT"
-  echo "[dry-run] PROJECT_NAME=$PROJECT_NAME"
-  echo "[dry-run] FEATURE_NAME=$FEATURE_NAME"
-  echo "[dry-run] FD_APP_ROOT=$FD_APP_ROOT"
-  echo "[dry-run] FSP_PATH=$FSP_PATH"
-  echo "[dry-run] BUILD_DIR=$BUILD_DIR"
-  echo "[dry-run] CONTEXT_FILE=$USER_ROOT/.seamos-context.json"
-  echo "[dry-run] NVX_DOCKER_IMAGE=$NVX_DOCKER_IMAGE"
-  echo "[dry-run] ARCH_TYPE=$ARCH_TYPE"
-  exit 0
-fi
 
 cd "$PROJ_ROOT"
 
@@ -354,6 +403,25 @@ else
     fi
 fi
 
+# ─── Dry-run output (v4 CIMP-4: expose key paths) ──────────────────────────
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "[dry-run] USER_ROOT=$USER_ROOT"
+  echo "[dry-run] PROJECT_NAME=$PROJECT_NAME"
+  echo "[dry-run] FEATURE_NAME=$FEATURE_NAME"
+  echo "[dry-run] FD_APP_ROOT=$FD_APP_ROOT"
+  echo "[dry-run] FSP_PATH=$FSP_PATH"
+  echo "[dry-run] BUILD_DIR=$BUILD_DIR"
+  echo "[dry-run] CONTEXT_FILE=$USER_ROOT/.seamos-context.json"
+  echo "[dry-run] NVX_DOCKER_IMAGE=$NVX_DOCKER_IMAGE"
+  echo "[dry-run] ARCH_TYPE=$ARCH_TYPE"
+  echo "[dry-run] APP_TYPE: $APP_TYPE"
+  echo "[dry-run] APP_PATH: $APP_PATH"
+  echo "[dry-run] SDK_PATH: $SDK_PATH"
+  echo "[dry-run] DISK_POLICY: will exclude disk/* except disk/seed/"
+  echo "[dry-run] DISK_SCAN_RESULT: $(disk_packaging_policy --dry-run "$APP_PATH")"
+  exit 0
+fi
+
 echo "[2/7] Project validated"
 echo "  Feature: $FEATURE_NAME"
 echo "  Type: $APP_TYPE"
@@ -434,6 +502,7 @@ if [ "$APP_TYPE" = "java" ]; then
     rm -rf "/tmp/nvx/app_proj/$(basename "$APP_PATH")/target"
     # Exclude DB files from FIF package
     rm -f /tmp/nvx/app_proj/*/disk/*.mv.db /tmp/nvx/app_proj/*/disk/*.trace.db /tmp/nvx/app_proj/*/disk/*.mv.db.backup_*
+    [ -n "$APP_PATH" ] && disk_packaging_policy "/tmp/nvx/app_proj/$(basename "$APP_PATH")"
     cp "$JAR_FILE" /tmp/nvx/java_app_jar/
 else
     mkdir -p /tmp/nvx/{fsp_proj,app_proj,sdk_proj}
@@ -455,6 +524,7 @@ else
     if [ "$SDK_EXTRACTED" = "1" ]; then
         rm -rf "$SDK_PATH"
     fi
+    [ -n "$APP_PATH" ] && disk_packaging_policy "/tmp/nvx/app_proj/$(basename "$APP_PATH")"
 fi
 
 echo "[5/7] Build files ready"
@@ -496,9 +566,24 @@ docker cp "$CONTAINER":/fif_output /tmp/nvx/fif_output
 
 # Copy .fif files to $BUILD_DIR for skill chaining (upload-app, update-app)
 mkdir -p "$BUILD_DIR"
-cp /tmp/nvx/fif_output/*.fif "$BUILD_DIR/" 2>/dev/null
+BUILD_DIR_FIFS=()
+while IFS= read -r -d '' src; do
+  cp "$src" "$BUILD_DIR/"
+  BUILD_DIR_FIFS+=("$BUILD_DIR/$(basename "$src")")
+done < <(find /tmp/nvx/fif_output -maxdepth 1 -name '*.fif' -type f -print0 | sort -z)
 
-FIF_FILE=$(ls "$BUILD_DIR"/*.fif 2>/dev/null | head -1)
+if [[ ${#BUILD_DIR_FIFS[@]} -eq 0 ]]; then
+  echo "No FIF artifact produced" >&2
+  exit 1
+fi
+
+echo "Built FIF artifacts (${#BUILD_DIR_FIFS[@]}):"
+for f in "${BUILD_DIR_FIFS[@]}"; do
+  echo "  - $f"
+done
+PRIMARY_FIF="${BUILD_DIR_FIFS[0]}"
+FIF_FILE="$PRIMARY_FIF"
+
 if [ -n "$FIF_FILE" ]; then
     FIF_SIZE=$(du -h "$FIF_FILE" | cut -f1)
     echo ""

--- a/skills/build-fif/scripts/test/test-disk-policy.sh
+++ b/skills/build-fif/scripts/test/test-disk-policy.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# test-disk-policy.sh — Unit tests for build-fif.sh disk_packaging_policy()
+#
+# Validates:
+#   (a) apply mode emits "Excluded N files from disk/, retained M files in disk/seed/"
+#   (b) apply mode keeps disk/seed/ files and removes disk/cache/, disk/persistence/, etc.
+#   (c) --dry-run emits "would exclude ..." and performs no deletion
+#   (d) absent disk/ directory yields "(no disk/ directory)"
+#
+# Sandbox: all mock workspaces live under mktemp -d /tmp/seamos-test-disk-XXXXXX
+# and are removed via trap on EXIT. No Docker. No user-home writes.
+set -euo pipefail
+
+TMPDIR=$(mktemp -d /tmp/seamos-test-disk-XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BUILD_FIF_SH="/Users/sungmincho/Desktop/Backend/seamos-everywhere/skills/build-fif/scripts/build-fif.sh"
+
+# Extract only the disk_packaging_policy() function body to avoid triggering
+# build-fif.sh's main flow on source. The function contains no nested function
+# definitions, so the awk range terminates at the first top-level "}" line.
+FUNC_FILE="$TMPDIR/func.sh"
+awk '/^disk_packaging_policy\(\)/,/^}$/' "$BUILD_FIF_SH" > "$FUNC_FILE"
+
+if [[ ! -s "$FUNC_FILE" ]]; then
+  echo "FAIL: failed to extract disk_packaging_policy from $BUILD_FIF_SH"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$FUNC_FILE"
+
+if ! type disk_packaging_policy >/dev/null 2>&1; then
+  echo "FAIL: disk_packaging_policy not sourced as function"
+  exit 1
+fi
+
+PASS_COUNT=0
+FAIL_LIST=()
+
+assert() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  ✓ $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  ✗ $name"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL_LIST+=("$name")
+  fi
+}
+
+# ─── (a) apply mode — stdout format ─────────────────────────────────────────
+mkdir -p "$TMPDIR/myapp/disk/seed" "$TMPDIR/myapp/disk/cache" "$TMPDIR/myapp/disk/persistence"
+echo '{}' > "$TMPDIR/myapp/disk/seed/init.json"
+echo 'cache' > "$TMPDIR/myapp/disk/cache/foo.bin"
+echo 'runtime' > "$TMPDIR/myapp/disk/persistence/runtime.db"
+
+OUT=$(disk_packaging_policy "$TMPDIR/myapp")
+assert "(a) apply mode stdout format" "$OUT" "Excluded 2 files from disk/, retained 1 files in disk/seed/"
+
+# ─── (b) only disk/seed/ files retained ─────────────────────────────────────
+KEPT=$(find "$TMPDIR/myapp/disk" -type f | wc -l | tr -d ' ')
+assert "(b) only disk/seed/ files retained" "$KEPT" "1"
+if [[ ! -f "$TMPDIR/myapp/disk/seed/init.json" ]]; then FAIL_LIST+=("(b) init.json missing"); fi
+if [[ -f "$TMPDIR/myapp/disk/cache/foo.bin" ]]; then FAIL_LIST+=("(b) cache file not removed"); fi
+if [[ -f "$TMPDIR/myapp/disk/persistence/runtime.db" ]]; then FAIL_LIST+=("(b) persistence file not removed"); fi
+
+# ─── (c) dry-run — count only, no deletion ──────────────────────────────────
+mkdir -p "$TMPDIR/myapp2/disk/seed" "$TMPDIR/myapp2/disk/cache"
+echo 'a' > "$TMPDIR/myapp2/disk/seed/a.json"
+echo 'b' > "$TMPDIR/myapp2/disk/seed/b.json"
+echo 'c' > "$TMPDIR/myapp2/disk/cache/c.bin"
+
+OUT2=$(disk_packaging_policy --dry-run "$TMPDIR/myapp2")
+assert "(c) dry-run stdout format" "$OUT2" "would exclude 1 files from disk/, would retain 2 files in disk/seed/"
+
+KEPT2=$(find "$TMPDIR/myapp2/disk" -type f | wc -l | tr -d ' ')
+assert "(c) dry-run does not delete" "$KEPT2" "3"
+
+# ─── (d) absent disk/ directory ─────────────────────────────────────────────
+mkdir -p "$TMPDIR/myapp3"
+OUT3=$(disk_packaging_policy "$TMPDIR/myapp3")
+assert "(d) absent disk/ message" "$OUT3" "(no disk/ directory)"
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then
+  echo ""
+  echo "PASS ($PASS_COUNT assertions)"
+  exit 0
+else
+  echo ""
+  echo "FAIL"
+  for f in "${FAIL_LIST[@]}"; do echo "  - $f"; done
+  exit 1
+fi

--- a/skills/regen-sdk-app/SKILL.md
+++ b/skills/regen-sdk-app/SKILL.md
@@ -21,6 +21,7 @@ Re-runs FD Headless in **UPDATE_SDK_APP** mode against an existing workspace. Bo
 | `interface.json` changed AND you want the test simulator scaffold (.gen.tests/) regenerated to reflect new providers | `create-project --regen-fsp-only` **then** `regen-sdk-app --reset-tests` | ✅ app code; ❌ .gen.tests/ (regenerated) |
 | Workspace is dirty / corrupted, OK to lose user app code | `create-project --force-clean --i-know-this-deletes-app-code` | ❌ (intentional) |
 | Upload a new `.fif` version to the SDM marketplace | `update-app` — wrong layer, different concept | n/a |
+| `disk/` (all subdirectories) | `regen-sdk-app` preserves it; `build-fif` packages only `disk/seed/` — see build-fif skill | ✅ |
 
 **Why `--force-clean` is no longer the default for interface changes**: it deletes the entire workspace including `<PROJECT>_<APP>/` (your hand-written code). `--regen-fsp-only` only deletes `com.bosch.fsp.<PROJECT>/` and re-runs `GENERATE_FSP`, leaving the app project intact for `regen-sdk-app` to merge into.
 
@@ -141,6 +142,7 @@ No docker invocation, no disk mutation. Emit these path variables to stdout (mir
 
 - **This skill refuses to run FSP regeneration**. FSP drift is handled explicitly by `create-project --regen-fsp-only` (FSP-only, app code preserved) or `create-project --force-clean --i-know-this-deletes-app-code` (full reset, opt-in). Single-responsibility per skill. If the user mentions interface changes, surface the two-step recipe instead of silently chaining.
 - **`.gen.tests/` is preserved by Bosch's UPDATE_SDK_APP** as user-data. After an interface change (e.g. adding a new plugin), the simulator scaffold (`SDKTest.java`, `data/sample_data.xml`, `data/Manifest.xml`) still references only the original providers and never publishes signals for the new ones. Pass `--reset-tests` to delete `.gen.tests/` so FD regenerates it from the current FSP/Manifest. The skill aborts if it detects `.java` files newer than `.classpath` under `src/` (likely user-edited); pass `--i-know-this-deletes-test-code` to override after copying anything you want to keep.
+- User's `disk/` directory is preserved across UPDATE_SDK_APP runs (same policy as `.gen.tests/`).
 - **Backing up app code**: UPDATE_SDK_APP is supposed to preserve your source, but since we cannot audit Bosch's merge logic, suggest the user commit or snapshot `<WORKSPACE>/<PROJECT>/<PROJECT>_<APP>/` before running — especially on the first use.
 - **`build-config-prop.sh` is shared** with `create-project` and lives under `skills/create-project/scripts/`. The only difference: this skill always passes `--app-project-path`; `create-project` Stage 1B never does.
 - **Context schema**: see `skills/shared-references/seamos-context-cache.md` — this skill adds `sdk_app_updated_at` (preserves `sdk_app_completed_at`).

--- a/skills/seamos-app-framework/SKILL.md
+++ b/skills/seamos-app-framework/SKILL.md
@@ -69,3 +69,10 @@ Read the pattern file and find the `##` section matching the selected pattern. A
   - **CMake link:** `find_package(Poco REQUIRED COMPONENTS Data DataSQLite)` + `target_link_libraries(... Poco::Data Poco::DataSQLite)` in the **project-root `CMakeLists.txt`** (preserved across `regen-sdk-app`), not in any file under `<APP>_CPP_SDK/` (regenerated).
 - REST/WebSocket patterns are NEVONEX-specific (NevonexRoute, UIWebServiceProvider). Standard HTTP frameworks do not apply.
 - **REST routes registered with `registerRoute("/path", ...)` are served on the app's WS port (default 1456 in `--via-fd-cli`), not the UI gateway port (6563).** The browser must call them through the `get_assigned_ports`-derived base URL — see `seamos-customui-client` for the client-side pattern.
+- **DB path conventions**:
+
+  | 경로 | 의미 | 빌드 시 | 런타임 |
+  |---|---|---|---|
+  | `./db/` | 작업 DB (working copy, gitignored) | 제외 | 런타임 생성 |
+  | `disk/<feature>/...` | 디바이스 영속 영역 (persistent) | 제외 | 디바이스에서 생성/유지 |
+  | `disk/seed/...` | 앱이 동봉하는 시드 데이터 | **포함 (allowlist)** | 첫 부팅 시 복사 |

--- a/skills/seamos-app-framework/references/usage-patterns/cpp.md
+++ b/skills/seamos-app-framework/references/usage-patterns/cpp.md
@@ -106,6 +106,8 @@ customui::UIWebServiceProvider::getInstance()->registerWebsocketRoute("/socket",
 
 ## DB Persistence
 
+C++ SQLite 의 working DB 는 `./db/<name>.db` 에 두며 빌드 시 제외된다. 디바이스 영속 DB 는 `disk/<feature>/runtime.db` 와 같이 `disk/<feature>/...` 하위에 위치하며 디바이스 측에서 런타임에 생성/유지한다 — 빌드 산출물(FIF) 에 포함되지 않는다. 앱이 의도적으로 동봉하는 시드 데이터(예: 초기 카탈로그 SQLite dump 또는 JSON) 는 `disk/seed/...` 하위에 두면 allowlist 정책으로 패키징되어 첫 부팅 시 디바이스로 복사된다.
+
 > **Note:** NEVONEX apps run in runc containers with ephemeral filesystems. App updates destroy all container-internal files. Use `FileProvider` to persist DB files to a host-mounted path that survives container restarts.
 
 **Architecture:**

--- a/skills/seamos-app-framework/references/usage-patterns/java.md
+++ b/skills/seamos-app-framework/references/usage-patterns/java.md
@@ -98,6 +98,8 @@ UIWebServiceProvider.getInstance().openWebsocket("/socket", UIWebsocketEndPoint.
 
 ## DB Persistence
 
+Java H2 의 working DB 는 `./db/<name>.h2.mv.db` 에 두며 빌드 시 제외된다. 디바이스 영속 DB 는 `disk/<feature>/persist.h2.mv.db` 와 같이 `disk/<feature>/...` 하위에 위치하며 디바이스 측에서 런타임에 생성/유지한다 — 빌드 산출물(FIF) 에 포함되지 않는다. 앱이 의도적으로 동봉하는 시드 데이터(예: 초기 카탈로그 SQL/JSON) 는 `disk/seed/...` 하위에 두면 allowlist 정책으로 패키징되어 첫 부팅 시 디바이스로 복사된다.
+
 > **Note:** NEVONEX apps run in runc containers with ephemeral filesystems. App updates destroy all container-internal files. Use `FCALFileProvider` to persist DB files to a host-mounted path that survives container restarts.
 
 **Architecture:**

--- a/skills/shared-references/seamos-context-cache.md
+++ b/skills/shared-references/seamos-context-cache.md
@@ -182,3 +182,54 @@ jq -e '.last_project.fsp_completed_at and .last_project.sdk_app_completed_at' \
 ### Concurrency
 
 Writes use `flock` when available, falling back to a `mkdir`-based lock directory (`.seamos-context.json.lock.d/`) for portability. Combined with `.tmp` + `mv`, the JSON file is always valid even under concurrent invocations.
+
+## last_app_register 영역
+
+`update-app` 스킬이 마지막으로 성공한 등록의 컨텍스트를 캐시한다. 디바이스/앱 캐시 및 last_project 영역과는 별개의 독립 영역으로, 같은 `.seamos-context.json` 파일 안에 공존한다.
+
+### 필드
+
+| 필드 | 타입 | 의미 |
+|---|---|---|
+| `last_app_register.feuType` | string | 마지막으로 성공적으로 등록한 feuType (예: `arable/cabin`) |
+| `last_app_register.arch` | string | 마지막 등록의 ARCH 토큰 (예: `RCU4-3Q`) |
+| `last_app_register.appId` | string | 마지막 등록 대상 appId — 다른 appId 호출 시 캐시 무용 |
+| `last_app_register.updatedAt` | string (ISO 8601) | 마지막 갱신 시각 |
+
+### 읽기/쓰기 책임
+
+| 스킬 | 읽기 | 쓰기 |
+|---|---|---|
+| `update-app` | fallback 블록 + FeuType 캐시 흐름 | 등록 성공 후 4 개 필드 갱신 |
+
+다른 스킬은 본 영역을 읽거나 쓰지 않는다.
+
+### JSON 예시
+
+```json
+{
+  "deviceId": "...",
+  "deviceName": "...",
+  "appId": "app_test_001",
+  "appName": "...",
+  "updatedAt": "2026-04-29T10:00:00Z",
+  "last_project": {
+    "name": "...",
+    "...": "..."
+  },
+  "last_app_register": {
+    "feuType": "arable/cabin",
+    "arch": "RCU4-3Q",
+    "appId": "app_test_001",
+    "updatedAt": "2026-04-29T11:30:00Z"
+  }
+}
+```
+
+### 사용 흐름
+
+1. `update-app` 시작 시 `last_app_register.appId` 가 현재 호출의 appId 와 일치하는지 검사한다.
+2. 일치하면 `last_app_register.feuType` 를 후보 목록의 *첫 항목* 으로 제시한다 ("(last used)" 라벨). 자동 채택은 하지 않는다.
+3. appId 가 다르면 본 영역을 무시한다 — 다른 앱의 등록 흔적이므로 후보로 노출하지 않는다.
+4. 등록이 성공적으로 끝나면 4 개 필드를 갱신한다. 실패한 시도는 캐시에 쓰지 않는다.
+5. 본 영역에는 캐시 만료(TTL) 정책이 없다 — appId 일치 여부만으로 유효성을 판단한다.


### PR DESCRIPTION
## 결함 요약 (CRITICAL)

`build-fif` 의 cleanup 단계가 사용자 워크스페이스의 `disk/` 디렉토리(개발 중 쌓인 H2/SQLite 운영 데이터 포함)를 통째로 FIF 에 패키징해 디바이스에 배포되던 회귀. Java cleanup 분기는 `*.mv.db` 정도만 부분 제거했고 **C++ 분기에는 대응 코드가 전무**했다. 결과적으로:

- 새 버전을 올릴 때마다 디바이스 운영 DB 가 빌드 시점 사본으로 **강제 롤백**됨
- 시드 데이터(공식 초기값) 와 우연히 남은 dev 데이터를 구별할 방법 없음
- 멀티 디바이스 동시 업데이트 시 모두 동일 snapshot 으로 통일됨

## 변경 요약

### Fixed — `disk_packaging_policy` 함수 도입
- `disk/seed/` 만 allowlist 로 보존, 그 외 `disk/**` 는 빌드 임시 사본에서 제거
- apply/dry-run 양쪽 지원, bash 3.2 호환, `set -e` 친화적
- Java/C++ cleanup 분기 양쪽에서 **빌드 임시 사본 경로**(`/tmp/nvx/app_proj/$(basename "\$APP_PATH")`) 에 호출 — 사용자 원본 워크스페이스는 절대 건드리지 않음
- DRY-RUN 출력에 `APP_TYPE`/`APP_PATH`/`SDK_PATH`/`DISK_POLICY`/`DISK_SCAN_RESULT` 5 필드 추가
- 산출물 캡처를 `cp ... 2>/dev/null` + `ls *.fif | head -1` 침묵 패턴에서 명시 배열 + 0 개 검출 에러 + 다중 FIF 보고로 교체

### Added — 3 경로 정책 6 개 문서에 일관 명시
- `./db/` (working DB, gitignored, 빌드 시 제외)
- `disk/<feature>/...` (persistent, 디바이스 측 생성, 빌드 시 제외)
- `disk/seed/...` (allowlist, 빌드 시 포함, 첫 부팅 시 디바이스로 복사)

대상 6 파일: `build-fif/SKILL.md`, `build-fif/references/build-details.md`, `seamos-app-framework/SKILL.md`, `seamos-app-framework/references/usage-patterns/java.md`, `seamos-app-framework/references/usage-patterns/cpp.md`, `regen-sdk-app/SKILL.md`

### Added — `last_app_register` 캐시 스키마
`shared-references/seamos-context-cache.md` 에 `update-app` 의 마지막 등록 컨텍스트를 캐시하는 영역 신설. 본 PR 은 스키마 정의만, `update-app` 본 동작 변경은 후속 PR (v0.5.7) 에서.

### Added — 회귀 방지 테스트
`skills/build-fif/scripts/test/test-disk-policy.sh` — 5 assertions

## Test plan

- [x] `bash -n skills/build-fif/scripts/build-fif.sh` 통과
- [x] `bash skills/build-fif/scripts/test/test-disk-policy.sh` → PASS (5/5)
  - apply mode stdout 포맷
  - `disk/seed/` 만 보존 검증
  - dry-run 포맷
  - dry-run 비파괴성
  - `disk/` 부재 안내 메시지
- [x] CHANGELOG.md 업데이트 (`## [0.5.6] — 2026-04-30`)
- [x] `.claude-plugin/plugin.json` version `0.5.5 → 0.5.6`
- [ ] 실 디바이스 e2e 검증 (다음 릴리즈 업로드 시 디바이스 DB 보존 확인)

## CONCERNS / 후속

- `build-fif.sh:421` dry-run 호출이 사용자 원본 `\$APP_PATH` 를 가리킴. 무삭제 카운트라 안전하지만 함수 동작 변경 시 회귀 가능 — 후속 정리 권장.
- legacy `build-fif.sh:504` 의 `rm -f /tmp/nvx/app_proj/*/disk/*.mv.db ...` 는 `disk_packaging_policy` 와 중복. 무해하나 정리 후보.
- CHANGELOG 가 v0.5.4 / v0.5.5 항목을 빠뜨린 채 v0.5.3 → v0.5.6 으로 이어짐 (별개 이슈, 본 PR 범위 밖).

## 관련 문서

- Plan: `seamos-everywhere/plans/[Plan] SeamOS 플러그인 결함 통합 — build-fif disk 패키징 + update-app feuType.md`
- Impl: `seamos-everywhere/implementations/[Impl] SeamOS 플러그인 결함 통합 — build-fif disk 패키징 + update-app feuType.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)