### PR TITLE
fix: v0.5.7 — update-app feuType 휴리스틱 제거 + ARCH/feuType 분리 + 캐시 흐름

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.5.7] — 2026-04-30
+
+`update-app` 의 fallback 흐름이 `.fif` 파일명에서 feuType 을 추정하던 휴리스틱을 제거. ARCH 토큰 파싱과 feuType 명시 질문을 분리하고, `last_app_register` 캐시(v0.5.6) 와 결합해 잘못된 feuType 으로 marketplace 에 등록되던 사고 경로를 차단.
+
+### Fixed — `update-app` 파일명 → feuType 휴리스틱이 잘못된 ARCH 등록을 유발
+
+기존 fallback 은 `get_app_status` 응답에 `feuType` 필드가 없을 때 `.fif` 파일명에서 `feuType` 을 *추정*(예: `RCU4-3Q-20.fif → RCU4-3Q/20`) 했음. 같은 앱이 여러 ARCH 변형으로 빌드된 경우(`RCU4-3Q-20.fif`, `RCU4-7Q-20.fif`) 파일명에서 feuType 을 결정할 수 없고, 잘못된 feuType 으로 marketplace 에 등록되거나 다른 ARCH 디바이스에 잘못된 바이너리가 배포되는 보안/배포 정합성 결함이었음.
+
+- 파일명에서는 ARCH 토큰만 파싱(`<ARCH>-<VERSION>.fif` 컨벤션). feuType 은 *추정하지 않고* 별도 단계로 분리해 사용자에게 명시 질문.
+- ARCH 토큰 파싱 실패 시 ARCH 와 feuType 모두 직접 입력 fallback.
+- `--feu-type FEU` / `--arch ARCH` argument-hint 추가 — 자동화 파이프라인이 인터랙티브 단계 없이 명시 주입 가능.
+- 다중 ARCH 빌드가 BUILD_DIR 에 공존할 때 어느 ARCH 를 등록할지 명시 선택 단계 추가.
+- 확인 프롬프트에 (appId, feuType, ARCH, version) 4-tuple 모두 표시. 한 호출당 하나의 feuType 정책 명문화.
+
+### Added — `last_app_register` 캐시 흐름
+
+`update-app` 이 등록 성공 후 `last_app_register.{feuType, arch, appId, updatedAt}` 4 필드를 캐시. 다음 호출 시 같은 appId 라면 후보 목록의 첫 항목으로 `<feuType> (last used)` 제시 — **자동 채택은 하지 않음**, 항상 사용자 확인. appId 가 다르면 캐시 무용.
+
+### Added — 회귀 방지 테스트
+
+- `update-app/scripts/test/test-fallback-doc.sh` — 13 개 assertion: argument-hint, ARCH/feuType 분리, 휴리스틱 어휘 0건, 단일 feuType 정책, 다중 ARCH 분기, fixture 유효성.
+- `update-app/scripts/test/fixtures/get_app_status_no_feutype.json` — `feuType` 키 부재 mock (fallback 진입 트리거 시뮬레이션).
+
 ## [0.5.6] — 2026-04-30
 
 `build-fif` 의 disk 무차별 패키징 결함을 잡고, 빌드/regen/runtime 의 3 경로 정책(`./db/` working / `disk/<feature>/` persistent / `disk/seed/` allowlist) 을 6 개 문서에 일관 명시. `update-app` 측 fallback 휴리스틱 제거를 위한 `last_app_register` 캐시 스키마 신설(`update-app` 본 동작 변경은 v0.5.7 에서 따라옴).

--- a/skills/update-app/SKILL.md
+++ b/skills/update-app/SKILL.md
@@ -3,7 +3,7 @@ name: update-app
 description: Upload a new version of an existing SeamOS app to the SDM marketplace. Use this skill whenever the user wants to update, upgrade, or push a new version of their app. Triggers on "앱 업데이트", "버전 업데이트", "새 버전 올려", "update app", "new version", "버전 업로드", "앱 버전". Also use when the user mentions updating a .fif file for an app that already exists on the marketplace, or wants to deploy a patch/update to a released app.
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write, Edit
-argument-hint: "[appId] [--dry-run]"
+argument-hint: "[appId] [--feu-type FEU] [--arch ARCH] [--dry-run]"
 ---
 
 # Update App Version on SDM Marketplace
@@ -105,27 +105,36 @@ Once the appId is determined, immediately call `get_app_status` MCP tool (`mcp__
 
 If appId is not found → warn user and go back to selection.
 
-**Fallback when `get_app_status` does not include feuType info:**
-The current backend response only returns a `versions` array — it does **not** carry a `feuType` field per version, so step 3-1 cannot show "현재 등록된 기기 타입" from this call alone. Detect this case and fall back gracefully:
+### 3-0. Fallback — `get_app_status` 응답에 `feuType` 이 없는 경우
 
-1. After parsing the response, check whether any version entry exposes a `feuType` (or equivalent) field.
-2. If **none** do, treat the registered-feuType list as **unknown** and skip the "이 앱에 등록된 기기 타입" subsection in step 3-1. Show only the .fif files found in `seamos-assets/builds/` and ask the user to either pick one of those filenames or type the feuType directly:
-   ```
-   현재 백엔드 응답에는 등록된 기기 타입 정보가 포함되어 있지 않습니다.
-   builds/ 폴더에서 발견한 파일을 기준으로 선택하거나 직접 입력해주세요:
-   1. AUTO-IT_RV-C1000.fif → feuType: AUTO-IT_RV-C1000
-   2. RCU4-3Q-20.fif       → feuType: RCU4-3Q/20  (파일명의 `-` 는 보통 `/` 로 환원되니 확인 필요)
-   직접 입력하려면 feuType 문자열을 그대로 적어주세요.
-   ```
-3. The same fallback applies to the **current version** lookup in step 3-2 — if the response does not include a per-feuType current version, ask the user for the version directly without an auto-suggested next-patch.
+응답에 `feuType` 키가 누락된 경우, 파일명에서 feuType 값을 도출하는 절차를 두지 않는다. 대신 다음 두 단계로 분리한다.
 
-This data is used in the next step for feuType selection and version suggestion.
+1. **ARCH 토큰 파싱**: `.fif` 파일명에서 ARCH 부분만 분리한다. 컨벤션은 `<ARCH>-<VERSION>.fif` — 마지막 `-` 앞까지가 ARCH, 뒤가 version. 예: `RCU4-3Q-20.fif` → ARCH=`RCU4-3Q`, version=`20`. 컨벤션을 따르지 않는 파일명(예: `myapp.fif`) 은 ARCH 인식에 실패한다.
+
+2. **feuType 명시 질문**: 사용자에게 다음 형식으로 묻는다 — "이 .fif 는 ARCH `<ARCH>` 빌드입니다. 어느 feuType 에 등록할까요?" 후보 목록은 (a) 컨텍스트 캐시의 `last_app_register.feuType` (해당 appId 일치 시, "(last used)" 라벨 부착), (b) `get_app_status` 가 부분적으로라도 반환한 기존 feuType 목록 — 합집합으로 제시. 후보가 없으면 빈 목록 + 직접 입력 안내. **후보를 임의 선택하지 않으며 — 항상 사용자 확인을 거친다.**
+
+3. **ARCH 인식 실패 fallback**: ARCH 토큰 파싱이 실패한 경우 "ARCH 를 자동 인식하지 못했습니다. 어느 ARCH 와 feuType 에 등록할까요?" 라는 메시지로 ARCH 와 feuType 둘 다 직접 입력 받는다.
+
+4. **`--feu-type` 명시 인자**: 호출 시 `--feu-type` 옵션이 주어졌다면 본 fallback 블록 전체를 skip 하고 해당 값을 그대로 사용한다 (ARCH 도 `--arch` 인자 우선). 자동화 파이프라인 대응 경로.
+
+### 3-0a. FeuType 캐시 흐름
+
+컨텍스트 캐시(`.seamos-context.json`) 의 `last_app_register` 영역을 읽고 쓴다.
+
+- **읽기 (fallback 단계)**: `last_app_register.feuType`, `last_app_register.arch`, `last_app_register.appId`, `last_app_register.updatedAt` 4개 필드를 읽는다. 현재 호출의 appId 와 캐시의 `last_app_register.appId` 가 *일치하는 경우에만* 후보 목록의 첫 항목으로 `<feuType> (last used)` 를 제시한다. **사용자 선택 없이 캐시 값을 그대로 반영하지 않으며 — 제시(suggest) 만 한다.**
+- **appId 불일치**: 캐시의 appId 와 다르면 lastFeuType 후보를 노출하지 않는다 — 다른 앱의 등록 흔적이므로 무용.
+- **쓰기 (등록 성공 후)**: 등록이 성공적으로 끝나면 같은 4개 필드를 갱신한다 (`updatedAt` 은 ISO 8601). 실패한 등록 시도는 캐시에 쓰지 않는다.
+- 본 영역은 다른 스킬이 사용하지 않는다 — `last_project`, 디바이스/앱 캐시 영역과 분리되어 있다 (`shared-references/seamos-context-cache.md` 참고).
 
 ### Step 3: Interactive Info Collection (one question at a time)
 
 Collect version info sequentially. Ask one question, wait for the answer, then ask the next. This keeps the interaction simple since there are only a few fields.
 
 #### 3-1. feuType Selection
+
+**다중 ARCH 빌드가 BUILD_DIR 에 공존하는 경우**: 한 워크스페이스에 `RCU4-3Q-20.fif` 와 `RCU4-7Q-20.fif` 처럼 여러 ARCH 의 `.fif` 가 동시에 존재할 수 있다. 이 경우 "여러 .fif 가 발견되었습니다. 어느 ARCH 를 등록하시겠습니까?" 형식으로 명시 선택을 받는다 — 자동으로 첫 번째를 고르지 않는다.
+
+본 호출은 한 번에 *하나의 feuType* 에만 대응한다 (one feuType per invocation). 여러 feuType 에 등록하려면 update-app 을 다시 실행한다.
 
 Present the feuTypes registered for this app (from Step 2-2) and the .fif files available in `seamos-assets/builds/`:
 
@@ -146,6 +155,13 @@ builds/ 폴더의 .fif 파일:
 **Wait for user response.**
 
 After selection, match the chosen feuType to a .fif file in builds/. If no matching file is found, tell the user which filename is expected and stop.
+
+확인 프롬프트 예시:
+```
+appId=app_test_001, feuType=arable/cabin, ARCH=RCU4-3Q, version=20 으로 업로드합니다. 진행할까요? [y/N]
+```
+
+위 4-tuple (appId, feuType, ARCH, target version) 을 모두 표시하여 사용자에게 최종 확인을 받는다.
 
 #### 3-2. Version Number
 

--- a/skills/update-app/scripts/test/fixtures/get_app_status_no_feutype.json
+++ b/skills/update-app/scripts/test/fixtures/get_app_status_no_feutype.json
@@ -1,0 +1,7 @@
+{
+  "appId": "app_test_001",
+  "appName": "Mock Test App",
+  "ownerId": "user_test_001",
+  "currentVersion": "0.0.1",
+  "deployedAt": null
+}

--- a/skills/update-app/scripts/test/test-fallback-doc.sh
+++ b/skills/update-app/scripts/test/test-fallback-doc.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_MD="/Users/sungmincho/Desktop/Backend/seamos-everywhere/skills/update-app/SKILL.md"
+CACHE_MD="/Users/sungmincho/Desktop/Backend/seamos-everywhere/skills/shared-references/seamos-context-cache.md"
+FIXTURE="/Users/sungmincho/Desktop/Backend/seamos-everywhere/skills/update-app/scripts/test/fixtures/get_app_status_no_feutype.json"
+
+PASS_COUNT=0
+FAIL_LIST=()
+
+assert_grep() {
+  local name="$1" pattern="$2" file="$3" min_count="${4:-1}"
+  local count
+  count=$(grep -cE "$pattern" "$file" 2>/dev/null) || count=0
+  if [[ "$count" -ge "$min_count" ]]; then
+    echo "  ✓ $name (${count} matches)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  ✗ $name — expected ≥${min_count}, got ${count}"
+    FAIL_LIST+=("$name")
+  fi
+}
+
+assert_no_grep() {
+  local name="$1" pattern="$2" file="$3"
+  local count
+  count=$(grep -cE "$pattern" "$file" 2>/dev/null) || count=0
+  if [[ "$count" -eq 0 ]]; then
+    echo "  ✓ $name (0 matches)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  ✗ $name — expected 0, got ${count}"
+    FAIL_LIST+=("$name")
+  fi
+}
+
+echo "Checking update-app/SKILL.md..."
+
+# (a) argument-hint 에 --feu-type 등장
+assert_grep "(a) argument-hint includes --feu-type" '^argument-hint:.*--feu-type' "$SKILL_MD"
+
+# (b) fallback 영역에 ARCH 와 feuType 모두 등장
+assert_grep "(b) fallback mentions ARCH" 'ARCH' "$SKILL_MD" 1
+assert_grep "(b) fallback mentions feuType" 'feuType' "$SKILL_MD" 1
+
+# (c) 금지어 부재 — 휴리스틱/heuristic/추정/infer/auto-select/auto-apply 가 fallback/캐시 절차 영역에 없음
+# (전체 파일 검사 — 본문에 어디든 등장하면 fail)
+assert_no_grep "(c) no '휴리스틱' (heuristic in Korean)" '휴리스틱' "$SKILL_MD"
+assert_no_grep "(c) no 'heuristic'" 'heuristic' "$SKILL_MD"
+assert_no_grep "(c) no 'auto-select'" 'auto-select' "$SKILL_MD"
+assert_no_grep "(c) no 'auto-apply'" 'auto-apply' "$SKILL_MD"
+
+# (d) last_app_register.feuType 토큰 존재
+assert_grep "(d) last_app_register.feuType referenced" 'last_app_register\.feuType' "$SKILL_MD"
+
+# (e) 단일 feuType 정책
+assert_grep "(e) one-feuType-per-invocation policy" '한 번에 하나의 feuType|one feuType per invocation' "$SKILL_MD"
+
+# (f) 다중 ARCH 분기 단락
+assert_grep "(f) multiple ARCH branch present" '다중 ARCH|multiple .fif' "$SKILL_MD"
+
+echo ""
+echo "Checking shared-references/seamos-context-cache.md..."
+
+# (g) last_app_register 토큰 ≥ 4 회 (헤더 + 4 필드)
+assert_grep "(g) last_app_register tokens (cache doc)" 'last_app_register' "$CACHE_MD" 4
+
+echo ""
+echo "Checking fixture..."
+
+command -v jq >/dev/null || { echo "jq not installed"; exit 1; }
+
+# Fixture 검증 — valid JSON 이고 feuType 키 없음
+if jq . "$FIXTURE" >/dev/null 2>&1; then
+  echo "  ✓ fixture is valid JSON"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "  ✗ fixture is not valid JSON"
+  FAIL_LIST+=("fixture-json")
+fi
+
+if jq -e '.feuType' "$FIXTURE" >/dev/null 2>&1; then
+  echo "  ✗ fixture should NOT contain feuType key"
+  FAIL_LIST+=("fixture-feutype-absent")
+else
+  echo "  ✓ fixture lacks feuType (fallback trigger)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+fi
+
+echo ""
+if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then
+  echo "PASS ($PASS_COUNT assertions)"
+  exit 0
+else
+  echo "FAIL"
+  for f in "${FAIL_LIST[@]}"; do echo "  - $f"; done
+  exit 1
+fi


### PR DESCRIPTION
## 결함 요약 (IMPORTANT)

`update-app` 의 fallback 흐름이 `.fif` 파일명에서 feuType 을 *추정* (예: `RCU4-3Q-20.fif → RCU4-3Q/20`) 했음. 이 휴리스틱이 깨지는 케이스들:

- 같은 앱이 여러 ARCH 변형으로 빌드된 경우 (`RCU4-3Q-20.fif`, `RCU4-7Q-20.fif`) 파일명에서 feuType 결정 불가
- 파일명 컨벤션이 `<ARCH>-<VERSION>.fif` 라고 명시된 곳이 없어서 휴리스틱이 깨지는 즉시 잘못된 feuType 으로 등록
- 자동화 파이프라인에서 feuType 을 명시 주입할 방법 없음 (`argument-hint` 가 `[appId] [--dry-run]` 뿐)

**결과**: 잘못된 feuType 으로 marketplace 에 등록되거나 **다른 ARCH 디바이스에 잘못된 바이너리가 설치되는** 보안/배포 정합성 결함.

## 변경 요약

### Fixed — fallback 휴리스틱 제거 + ARCH/feuType 분리
- 파일명에서는 ARCH 토큰만 파싱(`<ARCH>-<VERSION>.fif` 컨벤션)
- feuType 은 *추정하지 않고* 별도 단계로 분리해 사용자에게 명시 질문
- ARCH 토큰 파싱 실패 시 ARCH 와 feuType 모두 직접 입력 fallback
- `--feu-type FEU` / `--arch ARCH` argument-hint 추가 — 자동화 파이프라인이 인터랙티브 단계 없이 명시 주입 가능
- 다중 ARCH 빌드가 BUILD_DIR 에 공존할 때 어느 ARCH 를 등록할지 명시 선택 단계 추가
- 확인 프롬프트에 (appId, feuType, ARCH, version) 4-tuple 모두 표시
- 한 호출당 하나의 feuType 정책 명문화

### Added — `last_app_register` 캐시 흐름
- 등록 성공 후 `last_app_register.{feuType, arch, appId, updatedAt}` 4 필드를 캐시
- 다음 호출 시 같은 appId 라면 후보 목록의 첫 항목으로 `<feuType> (last used)` 제시
- **자동 채택은 하지 않음**, 항상 사용자 확인
- appId 가 다르면 캐시 무용

### Added — 회귀 방지 테스트
- `update-app/scripts/test/test-fallback-doc.sh` — 13 assertions
- `update-app/scripts/test/fixtures/get_app_status_no_feutype.json` — `feuType` 키 부재 mock

## Test plan

- [x] `bash skills/update-app/scripts/test/test-fallback-doc.sh` → PASS (13/13)
  - argument-hint 에 `--feu-type`/`--arch` 등장
  - fallback 영역에 ARCH 와 feuType 별도 분리
  - 휴리스틱 어휘(`휴리스틱`/`heuristic`/`auto-select`/`auto-apply`) 0건
  - `last_app_register.feuType` 토큰 + cache.md 토큰 ≥ 4
  - "한 번에 하나의 feuType" 정책 명시
  - 다중 ARCH 분기 단락 존재
  - fixture 가 valid JSON 이고 `feuType` 키 부재
- [x] CHANGELOG.md 업데이트 (`## [0.5.7] — 2026-04-30`)
- [x] `.claude-plugin/plugin.json` version `0.5.6 → 0.5.7`
- [ ] 실 marketplace 등록 시나리오 검증 (`update-app` 호출 → fallback 분기 → 사용자 확인)

## Dependencies

**Depends on #19 (v0.5.6)** — `last_app_register` 캐시 스키마는 PR #19 의 `shared-references/seamos-context-cache.md` 에 정의됨. 본 PR 의 base 는 `fix/build-fif-disk-allowlist-v0.5.6` 브랜치 (stacked PR). PR #19 머지 후 GitHub 가 자동으로 base 를 master 로 변경.

## CONCERNS / 후속

- `test-fallback-doc.sh` fixture 가 JSON 유효성/feuType 부재만 검사하고 실제 fallback 셸 로직을 실행하지 않음. 문서 검증으로는 충분하나 통합 테스트 별도 권장.
- argument-hint 에 `--arch` 추가했으나 `update.sh` 가 ARCH 인자를 받는지 별도 확인 필요 (현재는 `--app-file TYPE PATH` 페어 인자 받음). 자동화 파이프라인이 본 옵션을 사용하기 전에 스크립트 측 인자 파싱 보강 필요.

## 관련 문서

- Plan: `seamos-everywhere/plans/[Plan] SeamOS 플러그인 결함 통합 — build-fif disk 패키징 + update-app feuType.md`
- Impl: `seamos-everywhere/implementations/[Impl] SeamOS 플러그인 결함 통합 — build-fif disk 패키징 + update-app feuType.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)