### PR TITLE
feat: v0.5.9 — update.sh 에 --feu-type / --arch / --fif 인자 구현

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "seamos-everywhere",
       "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "author": {
         "name": "AGMO-Inc"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.5.9] — 2026-04-30
+
+v0.5.7 의 `update-app` SKILL.md `argument-hint` 가 광고하던 `--feu-type` / `--arch` 인자를 `update.sh` 도 직접 받도록 구현. 자동화 파이프라인이 인터랙티브 단계 없이 `update.sh` 를 직접 호출 가능 — 스킬 레이어 우회 경로 완성.
+
+### Added — `update.sh` 의 single-variant convenience 인자
+
+- `--feu-type FEU` — multipart part name (단일 variant 등록용).
+- `--fif PATH` — 명시적 `.fif` 경로.
+- `--arch ARCH` — `<ARCH>-*.fif` 패턴으로 BUILD_DIR 단일 매칭 자동 해석. 0 매칭 / 다중 매칭은 명시 에러 (자동 첫 번째 픽업 금지).
+- `--build-dir DIR` — `--arch` 해석 시 검색 루트 (기본 `./seamos-assets/builds`).
+- 본 4 개 인자는 기존 `--app-file TYPE PATH` 와 혼용 불가 — 하나의 호출은 한 vector 만 사용.
+- 본 변경 전에는 `update.sh` 가 `--app-file` 만 받아 자동화 파이프라인이 SKILL.md 의 인터랙티브 단계를 우회할 수 없었음 (`argument-hint` 와 `update.sh` 인자가 정합되지 않은 상태).
+
+### Added — `update-app/scripts/test/test-args.sh` 회귀 방지 테스트
+
+15 개 assertion: `--feu-type` + `--fif` 합성, `--arch` 단일 매칭 / 다중 / 0 매칭 분기, `--app-file` 와 mutual exclusion, `--feu-type` 단독 사용 시 에러, `--fif` / `--arch` 단독 사용 시 에러, legacy `--app-file` 경로 회귀 없음, `--dry-run` 의 API key 마스킹.
+
 ## [0.5.8] — 2026-04-30
 
 이전 두 패치(v0.5.6, v0.5.7) 의 후속 정리. CHANGELOG 의 v0.5.4 / v0.5.5 누락 엔트리 소급 보충, `disk_packaging_policy()` 의 dry-run 안전성을 구조적으로 분리, legacy 중복 cleanup 1 줄 제거. 사용자 코드 영향 없음.

--- a/skills/update-app/SKILL.md
+++ b/skills/update-app/SKILL.md
@@ -115,7 +115,7 @@ If appId is not found → warn user and go back to selection.
 
 3. **ARCH 인식 실패 fallback**: ARCH 토큰 파싱이 실패한 경우 "ARCH 를 자동 인식하지 못했습니다. 어느 ARCH 와 feuType 에 등록할까요?" 라는 메시지로 ARCH 와 feuType 둘 다 직접 입력 받는다.
 
-4. **`--feu-type` 명시 인자**: 호출 시 `--feu-type` 옵션이 주어졌다면 본 fallback 블록 전체를 skip 하고 해당 값을 그대로 사용한다 (ARCH 도 `--arch` 인자 우선). 자동화 파이프라인 대응 경로.
+4. **`--feu-type` 명시 인자**: 호출 시 `--feu-type` 옵션이 주어졌다면 본 fallback 블록 전체를 skip 하고 해당 값을 그대로 사용한다 (ARCH 도 `--arch` 인자 우선). 자동화 파이프라인 대응 경로. 본 스킬 인자는 `update.sh` 의 동일 이름 인자(`--feu-type FEU` / `--arch ARCH`) 로 그대로 전달 가능 — 인터랙티브 단계 없이 호출하려면 `--feu-type FEU --fif PATH` 또는 `--feu-type FEU --arch ARCH` (BUILD_DIR 의 `<ARCH>-*.fif` 단일 매칭 자동 해석) 조합 사용.
 
 ### 3-0a. FeuType 캐시 흐름
 
@@ -271,6 +271,20 @@ bash skills/update-app/scripts/update.sh \
   --request '{variants_json}' \
   --app-file "{feuType}" "{fif_path}"
 ```
+
+자동화 파이프라인이 단일 variant 만 등록하는 경우 `--feu-type` + (`--fif` | `--arch`) 조합도 사용 가능 — 결과적으로 동일한 multipart 요청 생성:
+
+```bash
+bash skills/update-app/scripts/update.sh \
+  --base-url "{base_url}" \
+  --api-key "{api_key}" \
+  --app-id {appId} \
+  --request '{variants_json}' \
+  --feu-type "{feuType}" \
+  --arch "{arch}"   # 또는 --fif "{fif_path}"
+```
+
+`--feu-type` / `--fif` / `--arch` 는 `--app-file` 과 혼용 불가. `--arch` 만 주어지면 BUILD_DIR (기본 `./seamos-assets/builds`) 에서 `<ARCH>-*.fif` 단일 매칭을 찾아 사용 — 0 매칭 / 다중 매칭은 명시 에러.
 
 Do NOT build or display the curl command yourself — always use the script, which handles API key masking internally.
 

--- a/skills/update-app/scripts/test/test-args.sh
+++ b/skills/update-app/scripts/test/test-args.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# test-args.sh — Argument parsing tests for update-app/scripts/update.sh
+#
+# Validates the new convenience flags introduced alongside the SKILL.md
+# argument-hint contract:
+#   --feu-type FEU   — multipart part name (required when using convenience flags)
+#   --fif PATH       — explicit .fif path
+#   --arch ARCH      — resolve .fif by '<ARCH>-*.fif' in --build-dir
+#   --build-dir DIR  — search root for --arch resolution
+#
+# Driven via --dry-run so no HTTP traffic. The dry-run output prints the
+# fully-assembled curl arg vector, which we grep for the synthesized
+# -F "feuType=@path" pair.
+#
+# Sandbox: all mock workspaces under mktemp -d /tmp/seamos-test-args-XXXXXX
+# and removed via trap on EXIT. No network. No user-home writes.
+set -euo pipefail
+
+TMPDIR=$(mktemp -d /tmp/seamos-test-args-XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+UPDATE_SH="/Users/sungmincho/Desktop/Backend/seamos-everywhere/skills/update-app/scripts/update.sh"
+BASE_URL="http://localhost:8088"
+API_KEY="testkey123"
+APP_ID="10000"
+REQUEST_JSON='{"variants":[]}'
+
+PASS_COUNT=0
+FAIL_LIST=()
+
+assert() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  ✓ $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  ✗ $name"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL_LIST+=("$name")
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  ✓ $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  ✗ $name"
+    echo "    expected to contain: $needle"
+    echo "    actual:              $haystack"
+    FAIL_LIST+=("$name")
+  fi
+}
+
+# ─── (a) --feu-type + --fif synthesizes a single -F pair ────────────────────
+mkdir -p "$TMPDIR/builds"
+echo 'fakefif' > "$TMPDIR/builds/RCU4-3Q-20.fif"
+
+OUT_A=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --feu-type "AUTO-IT_RV-C1000" \
+  --fif "$TMPDIR/builds/RCU4-3Q-20.fif" \
+  --dry-run)
+
+assert_contains "(a) --feu-type + --fif synthesizes -F pair" "$OUT_A" \
+  "AUTO-IT_RV-C1000=@$TMPDIR/builds/RCU4-3Q-20.fif"
+
+# ─── (b) --feu-type + --arch resolves .fif from --build-dir ─────────────────
+OUT_B=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --feu-type "AUTO-IT_RV-C1000" \
+  --arch "RCU4-3Q" \
+  --build-dir "$TMPDIR/builds" \
+  --dry-run)
+
+assert_contains "(b) --arch resolves single match" "$OUT_B" \
+  "AUTO-IT_RV-C1000=@$TMPDIR/builds/RCU4-3Q-20.fif"
+
+# ─── (c) --arch with multiple matches errors out ────────────────────────────
+echo 'fakefif2' > "$TMPDIR/builds/RCU4-3Q-21.fif"
+
+set +e
+OUT_C=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --feu-type "AUTO-IT_RV-C1000" \
+  --arch "RCU4-3Q" \
+  --build-dir "$TMPDIR/builds" \
+  --dry-run 2>&1)
+RC_C=$?
+set -e
+
+assert "(c) --arch multi-match exit code" "$RC_C" "1"
+assert_contains "(c) --arch multi-match error message" "$OUT_C" \
+  "multiple .fif matched"
+
+# ─── (d) --arch with zero matches errors out ────────────────────────────────
+set +e
+OUT_D=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --feu-type "AUTO-IT_RV-C1000" \
+  --arch "NONEXISTENT" \
+  --build-dir "$TMPDIR/builds" \
+  --dry-run 2>&1)
+RC_D=$?
+set -e
+
+assert "(d) --arch no-match exit code" "$RC_D" "1"
+assert_contains "(d) --arch no-match error message" "$OUT_D" \
+  "no .fif matched"
+
+# ─── (e) convenience + --app-file mutual exclusion ──────────────────────────
+set +e
+OUT_E=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --feu-type "AUTO-IT_RV-C1000" \
+  --fif "$TMPDIR/builds/RCU4-3Q-20.fif" \
+  --app-file "Other" "$TMPDIR/builds/RCU4-3Q-20.fif" \
+  --dry-run 2>&1)
+RC_E=$?
+set -e
+
+assert "(e) convenience + --app-file exit code" "$RC_E" "1"
+assert_contains "(e) convenience + --app-file mutual exclusion message" "$OUT_E" \
+  "cannot be combined with --app-file"
+
+# ─── (f) --feu-type without --fif/--arch errors out ─────────────────────────
+set +e
+OUT_F=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --feu-type "AUTO-IT_RV-C1000" \
+  --dry-run 2>&1)
+RC_F=$?
+set -e
+
+assert "(f) --feu-type alone exit code" "$RC_F" "1"
+assert_contains "(f) --feu-type alone error message" "$OUT_F" \
+  "provide --fif PATH or --arch ARCH"
+
+# ─── (g) --fif/--arch without --feu-type errors out ─────────────────────────
+set +e
+OUT_G=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --fif "$TMPDIR/builds/RCU4-3Q-20.fif" \
+  --dry-run 2>&1)
+RC_G=$?
+set -e
+
+assert "(g) --fif without --feu-type exit code" "$RC_G" "1"
+assert_contains "(g) --fif without --feu-type error message" "$OUT_G" \
+  "--feu-type is required"
+
+# ─── (h) legacy --app-file path still works ─────────────────────────────────
+OUT_H=$(bash "$UPDATE_SH" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --app-id "$APP_ID" \
+  --request "$REQUEST_JSON" \
+  --app-file "AUTO-IT_RV-C1000" "$TMPDIR/builds/RCU4-3Q-20.fif" \
+  --dry-run)
+
+assert_contains "(h) legacy --app-file path" "$OUT_H" \
+  "AUTO-IT_RV-C1000=@$TMPDIR/builds/RCU4-3Q-20.fif"
+
+# ─── (i) API key masking in dry-run ─────────────────────────────────────────
+assert_contains "(i) API key masked in dry-run output" "$OUT_A" \
+  "${API_KEY:0:6}***"
+
+# Negative: full API key should NOT appear after the masking marker.
+if echo "$OUT_A" | grep -q "X-API-Key: ${API_KEY}\b"; then
+  FAIL_LIST+=("(i) API key NOT masked")
+else
+  echo "  ✓ (i) raw API key absent from dry-run output"
+  PASS_COUNT=$((PASS_COUNT + 1))
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then
+  echo ""
+  echo "PASS ($PASS_COUNT assertions)"
+  exit 0
+else
+  echo ""
+  echo "FAIL"
+  for f in "${FAIL_LIST[@]}"; do echo "  - $f"; done
+  exit 1
+fi

--- a/skills/update-app/scripts/update.sh
+++ b/skills/update-app/scripts/update.sh
@@ -13,6 +13,16 @@ Required:
   --api-key KEY         API key with APP_DEPLOY scope
   --app-id ID           Existing app ID to update
   --request JSON        Variants metadata as JSON string
+
+Single-variant convenience flags (cannot mix with --app-file):
+  --feu-type FEU        feuType to register under (multipart part name)
+  --fif PATH            explicit .fif path
+  --arch ARCH           resolve .fif by '<ARCH>-*.fif' in --build-dir
+                        (must yield exactly one match; combine with --feu-type)
+  --build-dir DIR       directory to scan for .fif when --arch is set
+                        (default: ./seamos-assets/builds)
+
+Multi-variant flag (cannot mix with --feu-type/--fif/--arch):
   --app-file TYPE PATH  feuType name and path to .fif file (can repeat)
 
 Optional:
@@ -28,6 +38,10 @@ APP_ID=""
 REQUEST_JSON=""
 APP_FILES=()  # pairs of (feuType, path)
 DRY_RUN=false
+FEU_TYPE=""
+FIF_PATH=""
+ARCH=""
+BUILD_DIR="./seamos-assets/builds"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -37,18 +51,63 @@ while [[ $# -gt 0 ]]; do
     --request)    REQUEST_JSON="$2"; shift 2 ;;
     --app-file)
       APP_FILES+=("$2" "$3"); shift 3 ;;
+    --feu-type)   FEU_TYPE="$2"; shift 2 ;;
+    --fif)        FIF_PATH="$2"; shift 2 ;;
+    --arch)       ARCH="$2"; shift 2 ;;
+    --build-dir)  BUILD_DIR="$2"; shift 2 ;;
     --dry-run)    DRY_RUN=true; shift ;;
     -h|--help)    usage ;;
     *)            echo "Unknown option: $1"; usage ;;
   esac
 done
 
-# Validation
+# Validation — required base flags
 [[ -z "$BASE_URL" ]] && { echo "Error: --base-url is required"; exit 1; }
 [[ -z "$API_KEY" ]] && { echo "Error: --api-key is required"; exit 1; }
 [[ -z "$APP_ID" ]] && { echo "Error: --app-id is required"; exit 1; }
 [[ -z "$REQUEST_JSON" ]] && { echo "Error: --request is required"; exit 1; }
-[[ ${#APP_FILES[@]} -eq 0 ]] && { echo "Error: at least 1 --app-file required"; exit 1; }
+
+# Convenience flags (--feu-type/--fif/--arch) synthesize a single --app-file pair.
+# They cannot coexist with --app-file.
+HAS_CONVENIENCE=false
+if [[ -n "$FEU_TYPE" || -n "$FIF_PATH" || -n "$ARCH" ]]; then
+  HAS_CONVENIENCE=true
+fi
+
+if $HAS_CONVENIENCE && [[ ${#APP_FILES[@]} -gt 0 ]]; then
+  echo "Error: --feu-type/--fif/--arch cannot be combined with --app-file"
+  exit 1
+fi
+
+if $HAS_CONVENIENCE; then
+  [[ -z "$FEU_TYPE" ]] && { echo "Error: --feu-type is required when using --fif/--arch"; exit 1; }
+
+  # Resolve FIF_PATH if only --arch was given.
+  if [[ -z "$FIF_PATH" ]]; then
+    [[ -z "$ARCH" ]] && { echo "Error: provide --fif PATH or --arch ARCH"; exit 1; }
+    [[ -d "$BUILD_DIR" ]] || { echo "Error: --build-dir not found: $BUILD_DIR"; exit 1; }
+
+    MATCHES=()
+    while IFS= read -r -d '' f; do
+      MATCHES+=("$f")
+    done < <(find "$BUILD_DIR" -maxdepth 1 -type f -name "${ARCH}-*.fif" -print0 2>/dev/null | sort -z)
+
+    if [[ ${#MATCHES[@]} -eq 0 ]]; then
+      echo "Error: no .fif matched '${ARCH}-*.fif' in $BUILD_DIR"
+      exit 1
+    fi
+    if [[ ${#MATCHES[@]} -gt 1 ]]; then
+      echo "Error: multiple .fif matched '${ARCH}-*.fif' in $BUILD_DIR — pass --fif PATH explicitly:"
+      for m in "${MATCHES[@]}"; do echo "  - $m"; done
+      exit 1
+    fi
+    FIF_PATH="${MATCHES[0]}"
+  fi
+
+  APP_FILES+=("$FEU_TYPE" "$FIF_PATH")
+fi
+
+[[ ${#APP_FILES[@]} -eq 0 ]] && { echo "Error: at least 1 --app-file (or --feu-type + --fif/--arch) required"; exit 1; }
 
 # Verify files exist
 for ((i=1; i<${#APP_FILES[@]}; i+=2)); do


### PR DESCRIPTION
## Summary

v0.5.7 의 `update-app` SKILL.md `argument-hint` 가 광고하던 `--feu-type FEU --arch ARCH` 를 `update.sh` 가 직접 받도록 구현. 자동화 파이프라인이 인터랙티브 단계 없이 `update.sh` 를 직접 호출 가능 — 스킬 레이어 우회 경로 완성.

## 변경 내용

### `update.sh` 의 single-variant convenience 인자

| 인자 | 역할 |
|------|------|
| `--feu-type FEU` | multipart part name (단일 variant 등록용) |
| `--fif PATH` | 명시적 `.fif` 경로 |
| `--arch ARCH` | `<ARCH>-*.fif` 패턴으로 BUILD_DIR 단일 매칭 자동 해석. **0 매칭 / 다중 매칭은 명시 에러** (자동 첫 번째 픽업 금지) |
| `--build-dir DIR` | `--arch` 해석 시 검색 루트 (기본 `./seamos-assets/builds`) |

위 4 개 인자는 기존 `--app-file TYPE PATH` 와 **혼용 불가** — 한 호출은 한 vector 만 사용.

### 본 변경 전 한계

`update-app` 스킬의 `argument-hint` 는 `[appId] [--feu-type FEU] [--arch ARCH] [--dry-run]` 를 광고했으나, `update.sh` 는 `--app-file TYPE PATH` 만 받았음. 자동화 파이프라인이 SKILL.md 의 인터랙티브 단계 (feuType 선택, ARCH 확인 등) 를 우회하려 해도 `update.sh` 단에서 거부되던 상태.

### 사용 예시

```bash
# 명시 경로
update.sh ... --feu-type AUTO-IT_RV-C1000 --fif builds/RCU4-3Q-20.fif

# ARCH 자동 해석
update.sh ... --feu-type AUTO-IT_RV-C1000 --arch RCU4-3Q --build-dir builds/

# legacy (변경 없음, 다중 variant)
update.sh ... --app-file AUTO-IT_RV-C1000 builds/RCU4-3Q-20.fif --app-file Other builds/RCU4-7Q-20.fif
```

## Test plan

- [x] `bash -n update.sh` 통과
- [x] `test-args.sh` 15 assertion 통과 (synthesizes -F pair, `--arch` 단일/다중/0 매칭, `--app-file` mutual exclusion, `--feu-type` 단독 에러, `--fif` 단독 에러, legacy `--app-file` 회귀, dry-run API key 마스킹)
- [x] `test-fallback-doc.sh` 13 assertion 회귀 없음 (SKILL.md 수정 후)
- [x] CHANGELOG.md 에 v0.5.9 엔트리 추가
- [x] `plugin.json` ↔ `marketplace.json` version 일치 (`0.5.9`)
- [ ] 머지 후 GitHub Release `v0.5.9` 작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)