### PR TITLE
feat: seamos-customui-react 스킬 신설 — React + @seamos/ads 표준 UI 스킬

### DIFF
--- a/skills/seamos-customui-react/SKILL.md
+++ b/skills/seamos-customui-react/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: seamos-customui-react
+description: >
+  SeamOS CustomUI를 React + @seamos/ads (Agmo Design System)로 작성하는
+  표준 UI 스킬. 운영 중인 기계 위에서 동작하는 화면이라는 특수 환경(진동·
+  흔들림, 야외 직사광·저조도, 장갑 착용, 한 손 조작, 수~수십 시간 연속
+  작업)에 맞춘 사용자 경험 원칙(Core 7 + Operational Context 3)과 ADS
+  컴포넌트·토큰 사용 안내(MCP 기반)를 제공한다. 화면 구성·정보 우선순위·
+  컴포넌트 선택·터치 제스처·접근성 결정에 즉시 사용한다. 사용자가 자유
+  텍스트로 요청해도 본 스킬을 트리거: "CustomUI 만들어", "CustomUI에
+  버튼 추가", "토픽 데이터 화면에 보여줘", "모니터링 화면", "컨트롤 버튼",
+  "React로 SeamOS UI", "디자인 시스템 컴포넌트", "ADS 버튼/토글/입력",
+  "@seamos/ads 사용", "ADS 토큰 색상", "build CustomUI screen",
+  "add ADS button", "show topic data on screen", "use design system
+  component", "react SeamOS UI", "ads tokens for color/spacing".
+  통신 프로토콜(포트 디스커버리, WebSocket frame 구조, REST 호출 base
+  URL, cloud-proxy correlation-id)은 본 스킬 범위 밖 — `seamos-customui-client`
+  스킬로 위임한다. SeamOS 외부 웹앱(마켓플레이스 대시보드 등)이나
+  백엔드(Java/C++) 코드는 다루지 않는다.
+---
+
+# SeamOS CustomUI React
+
+SeamOS 앱의 CustomUI를 **React 18 + TypeScript + `@seamos/ads`** 표준으로
+짜기 위한 스킬. 본 스킬은 두 가지를 제공한다.
+
+1. **사용자 경험 원칙 10개** — 운영 중 기계 위에서 동작하는 화면이라는
+   특수 환경에 맞춘 강한 규약. 화면 구성·정보 우선순위·터치 제스처·
+   접근성 결정에 사용.
+2. **ADS 사용 안내** — `@seamos/ads`가 제공하는 토큰 카테고리와 ADS
+   MCP(`https://mcp.ads.seamos.io`) 호출 흐름. **컴포넌트 props·예제·
+   실제 토큰 값은 MCP가 진실의 출처**이며, 본 스킬은 추측 없이 MCP를
+   쓰도록 유도한다.
+
+통신(포트 디스커버리, WebSocket frame, REST, cloud-proxy)은 본 스킬
+범위 밖이며 `seamos-customui-client`가 책임진다. 본 스킬은 그 통신
+helper를 React hook으로 감싸 쓰는 패턴을 `references/react-patterns.md`에
+별도로 제공한다.
+
+## Why
+
+CustomUI는 일반 웹앱이 아니다. **운영 중인 기계 위에서 사용자가 다른
+한 손으로 조작기를 잡은 채 보는 화면**이다. 진동, 흔들림, 직사광, 장갑,
+연속 작업의 누적 피로 — 이 모든 제약이 일반 웹 UX의 default 가정을
+무너뜨린다. 이 스킬의 원칙은 그 제약에서 역산한 결과다.
+
+또한 ADS가 사내 표준 컴포넌트 라이브러리로 존재함에도, vanilla
+HTML/JS로 직접 짜는 사례가 늘어 일관성·접근성·테마 변경 비용이 깨질
+위험이 있다. **CustomUI = React + ADS = 표준**임을 본 스킬이 선언한다.
+
+## 사용 환경 (모든 원칙의 전제)
+
+- 진동·흔들림이 있는 운영 중 기계
+- 야외 직사광 ↔ 저조도 양극단
+- 장갑 착용 (정밀 터치 어려움)
+- 한 손 조작 (다른 손은 항상 핸들·레버·조작기)
+- 수~수십 시간 연속 작업
+
+## 사용자 경험 원칙
+
+상세 + 코드 예시는 `references/ux-principles.md`. 안티 패턴 카탈로그는
+`references/ux-anti-patterns.md`.
+
+### Core 7 — 운영 중 기계 UI 공통
+
+**1. Easy & Safe — 양손 UI 금지, 한 손으로 모두 가능**
+- ✅ 큰 단일 탭 타겟 (장갑 기준 최소 64dp)
+- ❌ 멀티 터치 제스처, 양손 가정 UI, 시선을 묶는 애니메이션·자동 스크롤
+
+**2. Glanceability + 즉시 응답 — 시선 1~2초, 입력 응답 0.25초**
+- ✅ 고대비, 큰 글자, 색에 더해 형태·위치로도 구분
+- ❌ 옅은 색만으로 구분, 작은 글자, 응답 지연 (= 사용자 중복 입력)
+
+**3. Consistency — ADS·SeamOS UI 표준 그대로**
+- ✅ ADS가 제공하는 아이콘·색·spacing 그대로
+- ❌ 임의 색상·아이콘 변형, 한 화면만의 special case 패턴
+
+**4. Simplicity in Content — 사용자 언어, 꼭 필요한 것만**
+- ✅ 작업 도메인의 자연어, 현재 흐름 직결 정보만, 매뉴얼 없이 시작
+- ❌ 시그널 이름·기술 약어 그대로 노출, 통계·로그를 모니터링 화면에 섞기
+
+**5. One Thing Per Screen — 한 화면 한 목표**
+- ✅ 작업 모니터링·설정·캘리브레이션 화면 분리, 모드별 화면 분리
+- ❌ 한 화면에서 모드 전환 + 모니터링 + 설정을 다 하기
+
+**6. Easy to Answer (3초) — 작업 중 입력 최소화**
+- ✅ OK/취소 같은 단순 confirm, 3초 안에 답 가능한 질문
+- ❌ 자유 텍스트 입력, 모호한 질문, 다중 선택지 + 긴 설명
+
+**7. Tap & Scroll (한 손) — 정밀 제스처 금지**
+- ✅ +/- 버튼·대형 다이얼, 세로 스크롤
+- ❌ 가로 스와이프, 작은 슬라이더, 정밀 드래그
+
+### Operational Context 3 — 운영 환경 특화
+
+**8. Status Persistence — 핵심 상태는 어디서나**
+- ✅ 동작/연료/온도·압력/작업기 상태/자동 모드 ON·OFF는 persistent status bar
+- ❌ 다른 화면 진입 시 핵심 상태가 사라지는 구조
+
+**9. Safety Override — 안전 알림은 모든 UI 위로**
+- ✅ 풀스크린 모달 + 시각/음성/햅틱 3중, 명시적 acknowledge 필요
+- ❌ Toast로 안전 알림, 자동 사라짐, 무시 가능한 배너
+
+**10. Resumable — 중단·재개 잦음**
+- ✅ 마지막 상태 기억 후 복귀 — 진행률·모드·미완료 입력 보존
+- ❌ "처음부터 다시" 강제, 새로고침 시 전체 초기화
+
+## ADS 사용 안내 (정보)
+
+`@seamos/ads`는 React 18 + TypeScript + CSS Variables 기반의 사내
+디자인 시스템. **실제 컴포넌트 props·사용 예제·CSS 변수 값은 ADS MCP가
+진실의 출처**이며, 본 스킬은 그것을 어떻게 호출할지만 안내한다.
+
+### MCP 도구
+
+| 도구 | 용도 |
+|---|---|
+| `list_components` | 전체 컴포넌트 목록 — 어떤 컴포넌트가 있는지 조회 |
+| `search_components(query)` | 키워드 검색 — "토글 비슷한 것", "입력 필드" 등 |
+| `get_component(name)` | 특정 컴포넌트의 props·예제·사용하는 CSS 변수 |
+
+### 메타 가이드
+
+- **추측으로 props 작성 금지** — 사용 직전 `get_component(name)` 호출
+- **모르는 컴포넌트는 `search_components`부터** — 이름을 추측해 직접
+  import하지 말 것
+- ADS의 **강한 사용 규약**(Detachment 금지·토큰만 사용·접근성 default 등)
+  은 ADS 자체 문서가 책임지는 영역이며, 본 스킬은 정보 안내만 한다
+
+### 토큰 카테고리
+
+ADS는 디자인 토큰을 CSS Variables (`--ads-*`) 형태로 제공한다. 실제
+이름·값은 MCP에서 가져온다. 카테고리는 다음과 같다.
+
+| 카테고리 | 변수 패턴 | 용도 |
+|---|---|---|
+| color | `var(--ads-color-*)` | 텍스트·배경·border·상태(success/warning/danger) 등 |
+| spacing | `var(--ads-spacing-*)` | margin·padding·gap |
+| typography | `var(--ads-font-*)`, `var(--ads-text-*)` | 폰트 크기·굵기·라인 높이 |
+| shadow | `var(--ads-shadow-*)` | elevation, focus ring |
+| radius | `var(--ads-radius-*)` | border-radius |
+| motion | `var(--ads-motion-*)` | duration, easing |
+
+상세 + 사용 패턴은 `references/ads-tokens.md`.
+
+## 통신 layer — `seamos-customui-client`
+
+CustomUI의 **데이터 통신**(포트 디스커버리, WebSocket frame, REST,
+cloud-proxy)은 본 스킬 범위 밖이다. 별도 스킬에서 책임진다.
+
+- 통신 프로토콜·hard rule: `seamos-customui-client` SKILL.md
+- 그 helper들을 React hook으로 감싸 쓰는 패턴: `references/react-patterns.md`
+  (본 스킬 안의 hook 예시)
+
+## Workflow — 트리거 시 흐름
+
+```
+사용자 의도 (예: "버튼 추가", "토픽 데이터 화면에 보여줘")
+    ↓
+[1] 사용자 경험 원칙 체크
+    - 어떤 화면인가? (모니터링 / 설정 / 알림)
+    - 한 화면 한 목표? Status Persistence·Safety Override 적용?
+    - 작업 중 사용? → 큰 타겟·자유 텍스트 금지·자동 스크롤 금지
+    ↓
+[2] ADS MCP 조회
+    - 모르는 컴포넌트 → search_components(query)
+    - 사용 직전 → get_component(name)으로 props·예제·변수 확인
+    - 권장 사용 패턴 그대로 따른다 (Flat/Compound는 컴포넌트별 상이)
+    ↓
+[3] 통신 필요 시 customui-client hook
+    - useApiBase / useTopic / usePublish / useExternalApi
+    - 통신 프로토콜 자체는 customui-client 스킬 참조
+    ↓
+[4] 사용자 경험 원칙 위배 여부 최종 체크
+    - 안티 패턴 카탈로그(`references/ux-anti-patterns.md`)와 대조
+    - 토큰 하드코딩 여부 확인
+    ↓
+코드 출력
+```
+
+## Hard rules
+
+- **추측으로 ADS 컴포넌트 props 작성 금지.** `get_component`로 확인.
+- **토큰 값 하드코딩 금지.** 색상·spacing·typography는 `var(--ads-*)`
+  CSS Variable로만.
+- **자유 텍스트 입력 금지.** 운영 중 키보드 사용 불가.
+- **가로 스와이프·정밀 드래그 금지.** 진동에서 오발생.
+- **양손 UI 금지.** 다른 한 손은 항상 조작기 위에 있다.
+
+## Cross-references
+
+- 통신 프로토콜 (포트, WS frame, REST base URL, cloud-proxy):
+  `seamos-customui-client`
+- 백엔드 (Java/C++ REST·WebSocket 서버, DB, lifecycle):
+  `seamos-app-framework`
+- 디자인 시스템 자체: ADS 레포 `https://github.com/AGMO-Inc/ADS`

--- a/skills/seamos-customui-react/references/ads-tokens.md
+++ b/skills/seamos-customui-react/references/ads-tokens.md
@@ -1,0 +1,120 @@
+# ADS Tokens — 카테고리 + 사용 패턴 + MCP 흐름
+
+ADS는 디자인 토큰을 **CSS Variables (`--ads-*`)** 형태로 제공한다.
+**실제 토큰 이름·값은 MCP의 `get_component`/`list_components`에서
+가져온다 — 본 문서는 카테고리·구조·사용 패턴만 안내한다.**
+
+---
+
+## 토큰 카테고리
+
+| 카테고리 | 변수 패턴 | 용도 |
+|---|---|---|
+| **color** | `var(--ads-color-*)` | 텍스트·배경·border, 상태(success/warning/danger), brand |
+| **spacing** | `var(--ads-spacing-*)` | margin·padding·gap, layout grid |
+| **typography** | `var(--ads-font-*)` / `var(--ads-text-*)` | font-family, size, weight, line-height |
+| **shadow** | `var(--ads-shadow-*)` | elevation, focus ring |
+| **radius** | `var(--ads-radius-*)` | border-radius |
+| **motion** | `var(--ads-motion-*)` | duration, easing |
+
+각 카테고리 안의 정확한 토큰 이름(예: `--ads-color-text-primary`,
+`--ads-spacing-md`)은 ADS 버전마다 다를 수 있으므로 **반드시 MCP에서
+조회**한다.
+
+---
+
+## 사용 패턴
+
+### CSS-in-JS / styled
+
+```tsx
+import { styled } from 'styled-components'  // 또는 ADS 권장 방식
+
+const Card = styled.div`
+  background: var(--ads-color-surface);
+  color: var(--ads-color-text-primary);
+  padding: var(--ads-spacing-md);
+  border-radius: var(--ads-radius-lg);
+  box-shadow: var(--ads-shadow-sm);
+`
+```
+
+### 인라인 style — 토큰만, 직접 값 금지
+
+```tsx
+// ❌ 직접 값
+<div style={{ color: '#1A1A1A', padding: 16 }} />
+
+// ✅ 토큰 변수
+<div style={{
+  color: 'var(--ads-color-text-primary)',
+  padding: 'var(--ads-spacing-md)',
+}} />
+```
+
+### ADS 컴포넌트의 props로 전달
+
+ADS 컴포넌트는 대부분 토큰을 내부적으로 사용한다. 사용자는 props
+이름만 알면 된다.
+
+```tsx
+// 컴포넌트가 토큰을 알아서 적용
+<Button variant="primary" size="lg">저장</Button>
+<Stack gap="md">...</Stack>
+```
+
+각 컴포넌트가 **어떤 props로 어떤 토큰을 받는지**는 `get_component`로
+확인.
+
+---
+
+## MCP 호출 흐름
+
+```
+[1] 모르는 컴포넌트 — 이름이 무엇인지 모름
+    → search_components(query)
+       예: search_components("토글 입력")
+       → 후보 목록과 짧은 설명 반환
+
+[2] 사용 직전 — props·예제·CSS 변수 확인
+    → get_component(name)
+       예: get_component("Button")
+       → props 시그니처, 사용 예제, 의존하는 CSS 변수 반환
+
+[3] 권장 패턴 그대로 사용
+    → MCP가 알려주는 권장 사용 예제를 따름
+       (Flat이든 Compound든 컴포넌트별로 권장 패턴이 다름)
+```
+
+### 안 되는 흐름
+
+```
+✗ 기억으로 props 적기 (sloppy)
+✗ 다른 디자인 시스템의 props 추측해서 적기 (예: Material UI 추측)
+✗ list_components 한 번 호출하고 그 결과를 캐싱해 며칠 동안 그대로
+   사용 (ADS 버전 업그레이드 후 깨짐)
+```
+
+---
+
+## 메타 가이드
+
+- **추측 금지.** ADS의 진실의 출처는 MCP다. 사용 직전 호출.
+- **토큰 값 하드코딩 금지.** 색상·spacing·typography를 직접 적으면
+  테마 변경/다크 모드/대비 모드 전환이 무력화된다.
+- **카테고리 외부 토큰 만들지 말 것.** 새 토큰이 필요하면 ADS 레포에
+  이슈/PR.
+- **var(--ads-*)가 아닌 변수 이름 패턴**이 필요하다고 느낀다면 ADS가
+  그 카테고리를 아직 정의하지 않은 것 — ADS에 보고.
+
+---
+
+## 토큰 조회 빠른 참조
+
+| 상황 | 호출 |
+|---|---|
+| "어떤 컴포넌트들이 있는지 보고 싶다" | `list_components` |
+| "버튼 비슷한 게 있나?" | `search_components("button")` |
+| "Button 어떻게 쓰는지 정확히 알고 싶다" | `get_component("Button")` |
+| "토글이 있나? 이름이 뭐지?" | `search_components("toggle switch")` |
+| "이 컴포넌트가 쓰는 CSS 변수는?" | `get_component(name)` 응답의 변수 섹션 |

--- a/skills/seamos-customui-react/references/react-patterns.md
+++ b/skills/seamos-customui-react/references/react-patterns.md
@@ -1,0 +1,280 @@
+# React Patterns — customui-client helper의 hook 래핑
+
+`seamos-customui-client` 스킬이 정의하는 vanilla helper(포트 디스커버리,
+WebSocket frame, REST 호출, cloud-proxy)를 React 18 + TypeScript에서
+hook으로 감싸 쓰는 패턴.
+
+> **통신 프로토콜 자체(왜 relative URL인지, 4-frame WS의 정확한
+> shape, correlation-id 동작 등)는 본 문서 범위 밖이다 —
+> `seamos-customui-client` SKILL.md를 참조.**
+
+본 문서는 **그 프로토콜 위에서 동작하는 React hook 형태의 사용 예시**
+만 제공한다.
+
+---
+
+## Hook 카탈로그
+
+| Hook | 책임 | customui-client의 어디 |
+|---|---|---|
+| `useApiBase()` | `get_assigned_ports` 호출 후 `http://hostname:port` base URL 반환 | port-discovery |
+| `useTopic(name)` | WS 토픽 구독, 마지막 frame 페이로드 반환 | ws-protocol (incoming `topic`) |
+| `usePublish()` | publish 헬퍼 — `readyState === OPEN` 체크 + 실패 처리 | ws-protocol (outgoing `publish`) |
+| `useExternalApi()` | cloud-proxy로 외부 HTTPS 호출, correlation-id 관리 | cloud-proxy |
+
+---
+
+## 1. `useApiBase()` — base URL
+
+```tsx
+import { useEffect, useState } from 'react'
+
+type ApiBaseState =
+  | { status: 'loading' }
+  | { status: 'ready'; baseUrl: string; port: number }
+  | { status: 'error'; error: Error }
+
+export function useApiBase(): ApiBaseState {
+  const [state, setState] = useState<ApiBaseState>({ status: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('get_assigned_ports', { cache: 'no-store' })   // 반드시 relative URL
+      .then(r => r.json())
+      .then((ports: Record<string, string | number>) => {
+        if (cancelled) return
+        const raw = Object.values(ports)[0]
+        const port = typeof raw === 'number' ? raw : Number.parseInt(String(raw), 10)
+        if (!Number.isFinite(port)) throw new Error('bad get_assigned_ports')
+        const baseUrl = `http://${location.hostname}:${port}`
+        setState({ status: 'ready', baseUrl, port })
+      })
+      .catch((error: Error) => {
+        if (!cancelled) setState({ status: 'error', error })
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  return state
+}
+```
+
+### 사용
+
+```tsx
+function CropList() {
+  const api = useApiBase()
+  if (api.status === 'loading') return <Skeleton />
+  if (api.status === 'error') return <ErrorBanner error={api.error} />
+
+  // api.baseUrl, api.port 사용 — 앱 등록 REST 라우트는 이 base 위
+  return <CropFetcher baseUrl={api.baseUrl} />
+}
+```
+
+### 주의
+
+- **`get_assigned_ports`는 반드시 relative URL.** 앞에 `/`를 붙이면
+  feature prefix를 벗어나 404. (자세한 이유: customui-client SKILL.md)
+- 반환값은 보통 string이므로 `Number.parseInt` + `Number.isFinite` 검증.
+
+---
+
+## 2. `useTopic(name)` — WS 토픽 구독
+
+```tsx
+import { useEffect, useRef, useState } from 'react'
+
+export function useTopic<T>(topicName: string): T | undefined {
+  const [data, setData] = useState<T | undefined>(undefined)
+  const wsRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetch('get_assigned_ports', { cache: 'no-store' })
+      .then(r => r.json())
+      .then(ports => {
+        if (cancelled) return
+        const raw = Object.values(ports)[0]
+        const port = Number.parseInt(String(raw), 10)
+        if (!Number.isFinite(port)) throw new Error('bad get_assigned_ports')
+
+        const ws = new WebSocket(`ws://${location.hostname}:${port}/socket`)
+        wsRef.current = ws
+
+        ws.onmessage = (ev) => {
+          const frame = JSON.parse(ev.data)
+          // customui-client SKILL.md ws-protocol.md 참고
+          if (frame.type === 'topic' && frame.topic === topicName) {
+            setData(frame.payload?.PL as T)
+          }
+        }
+        ws.onopen = () => {
+          // 구독 메시지 (정확한 shape는 customui-client 문서)
+          ws.send(JSON.stringify({ type: 'subscribe', topic: topicName }))
+        }
+      })
+
+    return () => {
+      cancelled = true
+      wsRef.current?.close()
+      wsRef.current = null
+    }
+  }, [topicName])
+
+  return data
+}
+```
+
+### 사용
+
+```tsx
+function EngineRpm() {
+  const rpm = useTopic<{ value: number }>('Engine.rpm')
+  return <Display label="엔진 회전수" value={rpm?.value ?? '—'} unit="rpm" />
+}
+```
+
+### 주의
+
+- **cleanup 필수**: 언마운트 시 `ws.close()`. 안 그러면 누수·중복 메시지.
+- `payload.PL` 파싱은 customui-client의 ws-protocol 규약을 그대로 따른다.
+- 앱이 재시작되면 ws가 silent close 되므로, 재연결 정책이 필요하면
+  여기에 reconnect 로직 추가 (지수 백오프 권장).
+
+---
+
+## 3. `usePublish()` — publish 헬퍼
+
+```tsx
+import { useCallback, useRef } from 'react'
+
+type PublishFn = (interfacePath: string, payload: unknown) => void
+
+export function usePublish(ws: WebSocket | null): PublishFn {
+  return useCallback((interfacePath, payload) => {
+    if (!ws) return
+    if (ws.readyState !== WebSocket.OPEN) {
+      console.warn('[publish] socket not open, dropping', interfacePath)
+      return
+    }
+    const frame = {
+      type: 'publish',
+      interface: interfacePath,
+      payload,
+    }
+    ws.send(JSON.stringify(frame))
+  }, [ws])
+}
+```
+
+### 사용
+
+```tsx
+function ToggleValve({ ws }: { ws: WebSocket | null }) {
+  const publish = usePublish(ws)
+  return (
+    <Button
+      size="xl"
+      label="밸브 열기"
+      onClick={() => publish('Implement.setAllSectionValveOpen', { open: true })}
+    />
+  )
+}
+```
+
+### 주의
+
+- **`readyState === OPEN` 체크 필수.** 앱이 재시작되면 socket이
+  silent close되고, closed socket에 send하면 throw.
+- `interface` 필드는 FD가 생성하는 interface 경로 (예:
+  `Implement.setAllSectionValveOpen`). 정확한 값은 `seamos-plugins`
+  스킬의 interface 합성 결과를 참조.
+
+---
+
+## 4. `useExternalApi()` — cloud-proxy로 외부 HTTPS
+
+```tsx
+import { useCallback, useEffect, useRef } from 'react'
+
+type ExternalApiCall = (req: { url: string; method: string; body?: unknown }) => Promise<unknown>
+
+export function useExternalApi(ws: WebSocket | null): ExternalApiCall {
+  const pendingRef = useRef<Map<string, (data: unknown) => void>>(new Map())
+
+  useEffect(() => {
+    if (!ws) return
+    const onMessage = (ev: MessageEvent) => {
+      const frame = JSON.parse(ev.data)
+      if (frame.type !== 'external_api_response') return
+      const cid = frame.correlationId
+      const resolver = pendingRef.current.get(cid)
+      if (resolver) {
+        resolver(frame.payload)
+        pendingRef.current.delete(cid)
+      }
+    }
+    ws.addEventListener('message', onMessage)
+    return () => ws.removeEventListener('message', onMessage)
+  }, [ws])
+
+  return useCallback((req) => {
+    return new Promise((resolve) => {
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        resolve({ error: 'socket not open' })
+        return
+      }
+      const cid = crypto.randomUUID()
+      pendingRef.current.set(cid, resolve)
+      ws.send(JSON.stringify({
+        type: 'external_api_request',
+        correlationId: cid,
+        ...req,
+      }))
+    })
+  }, [ws])
+}
+```
+
+### 사용
+
+```tsx
+function CloudUploadButton({ ws }: { ws: WebSocket | null }) {
+  const callExternal = useExternalApi(ws)
+  return (
+    <Button
+      size="xl"
+      label="구름에 업로드"
+      onClick={async () => {
+        const result = await callExternal({
+          url: 'https://api.example.com/upload',
+          method: 'POST',
+          body: { foo: 'bar' },
+        })
+        // ...
+      }}
+    />
+  )
+}
+```
+
+### 주의
+
+- **correlation-id 필수.** 같은 socket 위에서 여러 외부 호출이 돌면
+  응답이 out-of-order로 도착한다. cid로 매칭.
+- pending map 누수 방지를 위해 timeout도 함께 두는 것을 권장 (예제는
+  최소 형태).
+- 정확한 frame shape (`external_api_request` / `external_api_response`)는
+  customui-client SKILL.md의 cloud-proxy 섹션 참조.
+
+---
+
+## 공통 권장 사항
+
+- **상위에서 ws 인스턴스를 한 번만 만들고 context로 내려라.** 컴포넌트
+  마다 새 ws를 만들면 메시지 중복·연결 폭증.
+- **모든 hook이 unmount 시 cleanup**하는지 확인.
+- **에러 상태를 항상 노출**하라. silent failure는 운영 환경에서 가장
+  나쁜 패턴.

--- a/skills/seamos-customui-react/references/ux-anti-patterns.md
+++ b/skills/seamos-customui-react/references/ux-anti-patterns.md
@@ -1,0 +1,182 @@
+# UX Anti-Patterns — 카탈로그
+
+운영 중 기계 위 화면에서 **하지 말아야 할 패턴**과 **대안**. 각 항목:
+**증상 / 왜 안 되는가 / ❌ 코드 / ✅ 대안 코드**.
+
+---
+
+## 1. 가로 스와이프 네비게이션
+
+**증상.** 화면 전환·페이지 이동을 가로 스와이프로 처리.
+
+**왜 안 되는가.** 진동 환경에서 손이 화면 위에 있을 때 의도치 않은
+가로 움직임으로 페이지가 뒤바뀐다. 사용자는 "어, 왜 이 화면이 떴지?"
+하고 작업이 끊긴다.
+
+```tsx
+// ❌
+<SwipeableViews onSwipe={(idx) => setPage(idx)}>
+  <MonitoringPage />
+  <SettingsPage />
+</SwipeableViews>
+
+// ✅ — 명시적 탭 또는 메뉴
+<TabBar value={page} onChange={setPage}>
+  <Tab label="모니터링" value="monitor" />
+  <Tab label="설정" value="settings" />
+</TabBar>
+```
+
+---
+
+## 2. 자유 텍스트 입력
+
+**증상.** 작업명·메모·태그 등을 자유 텍스트로 받음.
+
+**왜 안 되는가.** 운전 중 키보드 사용 불가. 장갑으로 정확한 타이핑
+불가. 입력하려고 화면을 보는 시간 = 작업면을 못 보는 시간.
+
+```tsx
+// ❌
+<Input placeholder="작업명을 입력하세요" value={name} onChange={setName} />
+
+// ✅ — 사전 등록 + 선택
+<Select value={selected} onChange={setSelected}>
+  {presetWorks.map(w => <Option key={w.id} value={w.id}>{w.name}</Option>)}
+</Select>
+{/* 자유 입력이 정말 필요하면 작업 후 별도 화면(정차 모드)에서 */}
+```
+
+---
+
+## 3. 자동 스크롤 텍스트 (마퀴·티커)
+
+**증상.** 긴 메시지·알림이 좌→우 또는 상→하로 자동 흐름.
+
+**왜 안 되는가.** 시선이 텍스트 움직임에 묶여 작업면을 못 본다.
+Pleos Connect 가이드는 명시적으로 "auto-scrolling text 금지". 또한
+사용자는 자신의 페이스로 읽을 권리가 있다.
+
+```tsx
+// ❌
+<Marquee>매우 긴 알림 텍스트가 자동으로 흐릅니다...</Marquee>
+
+// ✅ — 정적 표시, 잘리면 ellipsis, 상세는 별도 진입
+<Banner>
+  <Text truncate>매우 긴 알림 텍스트가...</Text>
+  <Button label="자세히" onClick={openDetail} />
+</Banner>
+```
+
+---
+
+## 4. 색에만 의존한 의미 구분
+
+**증상.** success는 초록, danger는 빨강 — 색 외 단서 없음.
+
+**왜 안 되는가.** 직사광에서 색이 바래져 구분 불가. 색맹 사용자는
+구분 불가. 시야 외곽에서 보이는 색 변화를 놓칠 수 있다.
+
+```tsx
+// ❌
+<Indicator color={status === 'ok' ? 'green' : 'red'} />
+
+// ✅ — 색 + 아이콘 + 위치 + 텍스트
+<Indicator
+  color={status === 'ok' ? 'success' : 'danger'}
+  icon={status === 'ok' ? 'check' : 'alert'}
+  label={status === 'ok' ? '정상' : '점검 필요'}
+/>
+```
+
+---
+
+## 5. 작은 터치 타겟
+
+**증상.** 32~40px 정도의 작은 버튼·아이콘 탭.
+
+**왜 안 되는가.** 장갑 끼고 정확히 누르기 어려움. 진동에서 인접 버튼
+오발생. 결과적으로 사용자는 두세 번 시도하게 되어 시간 손실.
+
+```tsx
+// ❌
+<IconButton icon="settings" size="sm" />   /* 32px */
+
+// ✅ — 최소 64dp
+<IconButton icon="settings" size="xl" />   /* 64px+ */
+{/* 인접 버튼 사이 간격도 16dp 이상 */}
+```
+
+---
+
+## 6. 양손 UI (멀티 터치 제스처)
+
+**증상.** 핀치 줌, 두 손가락 회전, 두 손가락 스와이프.
+
+**왜 안 되는가.** 사용자의 다른 한 손은 항상 핸들·레버 위에 있다.
+양손을 화면에 올려야 한다는 것은 그 순간 기계 조작을 멈추거나 위험을
+감수해야 한다는 뜻.
+
+```tsx
+// ❌
+<MapView gestures={['pinch', 'rotate', 'twoFingerPan']} />
+
+// ✅ — 단일 탭 버튼으로 동일 기능
+<MapView>
+  <ZoomControls>
+    <Button label="+" onClick={zoomIn} size="xl" />
+    <Button label="−" onClick={zoomOut} size="xl" />
+  </ZoomControls>
+  <Button label="북쪽으로" onClick={resetRotation} size="xl" />
+</MapView>
+```
+
+---
+
+## 7. 깜빡거리는 알림 애니메이션
+
+**증상.** 위험·경고를 빠른 깜빡임(1초 미만 주기)으로 표시.
+
+**왜 안 되는가.** 시선이 묶여 작업면을 못 본다. 광과민성 발작 위험.
+사용자가 알림을 본 뒤에도 계속 깜빡이면 인지 부담 누적. WCAG도
+3 flashes/second 초과 금지를 명시.
+
+```tsx
+// ❌
+<Alert blink interval={500} />   /* 0.5초마다 깜빡 */
+
+// ✅ — 정적 강조 + 명시적 acknowledge
+<Alert
+  severity="warning"
+  icon="alert"
+  pulse="slow"   /* 필요하면 매우 느린 1회성 펄스만 */
+  requireAck
+/>
+```
+
+---
+
+## 8. 모달 무한 누적 (스택)
+
+**증상.** A 모달 위에 B 모달, 그 위에 C 모달이 쌓임. 사용자는 어느
+모달의 어느 액션이 어디로 가는지 잃는다.
+
+**왜 안 되는가.** 작업 중 사용자는 컨텍스트 스택을 머릿속에 들고
+있을 여유가 없다. 한 번에 하나의 결정만 노출해야 한다 (One Thing Per
+Screen 연장선).
+
+```tsx
+// ❌
+<Modal open={modalA}>
+  <Modal open={modalB}>   {/* B가 A 위에 */}
+    <Modal open={modalC}>...</Modal>
+  </Modal>
+</Modal>
+
+// ✅ — 한 번에 하나, 다음 단계는 같은 모달 내부에서
+<Modal open={open} step={step}>
+  {step === 1 && <StepA onNext={() => setStep(2)} />}
+  {step === 2 && <StepB onNext={() => setStep(3)} />}
+  {step === 3 && <StepC onClose={close} />}
+</Modal>
+```

--- a/skills/seamos-customui-react/references/ux-principles.md
+++ b/skills/seamos-customui-react/references/ux-principles.md
@@ -1,0 +1,317 @@
+# UX Principles — 상세
+
+각 원칙: **왜 / ✅ Do / ❌ Don't / 예시**.
+
+전제 환경: 진동·흔들림이 있는 운영 중 기계, 야외 직사광·저조도, 장갑
+착용, 한 손 조작, 수~수십 시간 연속 작업.
+
+---
+
+## Core 7
+
+### 1. Easy & Safe — 한 손, 양손 UI 금지
+
+**왜.** 사용자의 다른 한 손은 항상 핸들·조작 레버 위에 있다. UI가
+양손을 요구하면 그 순간 기계 조작이 멈추거나 위험해진다. 진동 환경에서
+정밀한 손동작은 실패한다.
+
+**✅ Do**
+- 모든 인터랙션을 큰 단일 탭으로 가능하게
+- 장갑 기준 최소 64dp 터치 타겟
+- 작업면에서 시선이 떠나지 않도록 시각 자극 최소화
+
+**❌ Don't**
+- 멀티 터치 제스처 (핀치 줌, 두 손가락 탭)
+- 한 손가락으로 누르는 동시에 다른 손가락으로 끄는 방식
+- 시선을 빨아들이는 트랜지션·자동 스크롤 텍스트
+
+```tsx
+// ❌
+<View onTouchStart={handlePinchStart} onTouchMove={handlePinchMove} />
+
+// ✅
+<Stack gap="lg">
+  <Button size="xl" label="확대" onClick={zoomIn} />
+  <Button size="xl" label="축소" onClick={zoomOut} />
+</Stack>
+```
+
+---
+
+### 2. Glanceability + 즉시 응답 — 시선 1~2초, 입력 응답 0.25초
+
+**왜.** 작업 중 사용자가 디스플레이에 줄 수 있는 시간은 1~2초다. 그
+안에 정보를 인지하지 못하면 작업면에서 시선이 너무 오래 떠나 사고가
+난다. 입력 후 0.25초 안에 시각 피드백이 없으면 사용자는 "안 눌렸나?"
+라고 의심해서 다시 누르고, 그 결과 의도치 않은 중복 입력이 발생한다.
+
+**✅ Do**
+- 고대비 (직사광에서도 읽힘)
+- 큰 글자, 큰 숫자
+- 색에 더해 형태·위치·아이콘·텍스트로도 의미 구분
+- 입력 즉시 시각 피드백 (눌림 상태, 색 변화)
+
+**❌ Don't**
+- 옅은 회색만으로 비활성 표시 (직사광에서 안 보임)
+- 색만으로 success/danger 구분
+- 작은 글자, 한 줄에 너무 많은 정보
+- 응답 지연을 로딩 인디케이터로 가리기
+
+```tsx
+// ❌ — 색만으로 위험 표시
+<Text color="red">엔진 과열</Text>
+
+// ✅ — 색 + 아이콘 + 위치(상단 고정)
+<AlertBanner severity="danger" icon="thermometer" position="top-fixed">
+  엔진 과열
+</AlertBanner>
+```
+
+---
+
+### 3. Consistency — ADS·SeamOS UI 표준 그대로
+
+**왜.** 사용자는 한 디바이스에서 여러 앱을, 한 작업장에서 여러 브랜드의
+기계를 옮겨 다닌다. 아이콘·색·위치·인터랙션이 일관되어야 학습 비용이
+0에 가깝다. 한 화면만의 special case 패턴이 늘어나면 사용자는 매번
+다시 배워야 한다.
+
+**✅ Do**
+- ADS가 제공하는 컴포넌트·아이콘·색·spacing 그대로 사용
+- 도메인에 표준 표기·아이콘이 있으면 그것을 따름
+- "이 화면만 약간 다르게"의 유혹 거부
+
+**❌ Don't**
+- ADS 컴포넌트를 wrapping해 색·spacing 바꿔서 새 컴포넌트로 export
+- 한 화면에서만 다른 layout grid·typography
+- ADS 토큰을 우회해 직접 색 지정
+
+```tsx
+// ❌ — wrapping으로 임의 변형
+function MyButton(props) {
+  return <Button {...props} style={{ background: '#0066ff', borderRadius: 4 }} />
+}
+
+// ✅ — ADS 그대로
+<Button variant="primary" size="lg">저장</Button>
+```
+
+---
+
+### 4. Simplicity in Content — 사용자 언어, 꼭 필요한 것만
+
+**왜.** 매뉴얼을 보지 않는다. 첫 화면만 보고 시작 가능해야 한다. 시그널
+이름·약어·기술 용어를 그대로 노출하면 사용자는 매번 의미를 추측해야
+하고, 그 추측이 틀리면 작업이 잘못된다.
+
+**✅ Do**
+- **Casual Concept**: 사용자가 쓰는 작업 도메인 자연어
+- **Minimum Feature**: 현재 작업 흐름에 직결된 정보·기능만
+- **Less Policy**: 외워야 할 규칙·순서 최소화
+- 현장에서 이미 통용되는 표준 약어는 보존 (임의 한글화 금지)
+
+**❌ Don't**
+- 시그널 이름·CAN 약어·내부 코드 그대로 노출
+- 모니터링 화면에 통계·로그·설정 섞기
+- 첫 진입 시 "튜토리얼 7단계" 같은 강제 학습
+
+```tsx
+// ❌
+<Field label="Hyd_Press_Sensor_1">{value}</Field>
+
+// ✅
+<Field label="유압">{value} bar</Field>
+```
+
+---
+
+### 5. One Thing Per Screen — 한 화면 한 목표
+
+**왜.** 작업 중 사용자가 동시에 처리할 수 있는 것은 하나다. 한 화면에
+여러 목표가 섞이면 어디를 봐야 할지 결정하는 데 1~2초가 더 걸린다.
+모드 전환 UI가 모니터링 화면에 같이 있으면 운전 중 잘못 누른다.
+
+**✅ Do**
+- 작업 중 = 모니터링만
+- 설정·캘리브레이션·로그는 별도 화면
+- 모드(작업/주행/대기)별로 다른 화면
+
+**❌ Don't**
+- 한 화면에 모니터링 + 모드 전환 + 설정 모두
+- 작업 화면 안의 미니 설정 패널
+- "고급 옵션" 토글로 같은 화면을 두 모드로 쓰기
+
+```tsx
+// ❌
+<Screen>
+  <Monitoring />
+  <ModeSelector />     {/* 운전 중 잘못 눌림 */}
+  <SettingsPanel />
+</Screen>
+
+// ✅
+<MonitoringScreen />
+{/* 모드 전환은 별도 화면, 명시적 진입 */}
+```
+
+---
+
+### 6. Easy to Answer (3초) — 작업 중 입력 최소화
+
+**왜.** 작업 중 사용자가 답할 수 있는 시간은 3초다. 그 안에 답이 안
+나오면 질문이 잘못된 것이다. 자유 텍스트 입력은 운전 중 키보드 사용이
+불가하므로 원천 금지.
+
+**✅ Do**
+- 모든 confirm·모달은 OK/취소 같은 단순 선택
+- 다지선다는 2~3개 선택지까지
+- 미리 정의된 값 중 선택 (사전 등록·메뉴)
+
+**❌ Don't**
+- 자유 텍스트 입력 (작업명·메모 등은 작업 후 별도 화면)
+- 모호한 질문 ("계속 진행할까요?" — 무엇을?)
+- 5개 이상 선택지
+
+```tsx
+// ❌
+<Modal>
+  <Input placeholder="작업명을 입력하세요" />
+</Modal>
+
+// ✅
+<Modal>
+  <RadioGroup>
+    <Radio value="A">A 구역</Radio>
+    <Radio value="B">B 구역</Radio>
+  </RadioGroup>
+</Modal>
+```
+
+---
+
+### 7. Tap & Scroll (한 손) — 정밀 제스처 금지
+
+**왜.** 진동 환경에서 정밀 슬라이더·작은 드래그는 의도치 않게 발생하거나
+의도한 값으로 안 멈춘다. 가로 스와이프는 흔들림으로 자주 오발생한다.
+세로 스크롤은 큰 영역에서 천천히 굴려도 동작하므로 진동 환경에서도 안전.
+
+**✅ Do**
+- +/- 버튼, 대형 다이얼, 스텝 입력
+- 세로 스크롤
+- 큰 토글 스위치 (단일 탭)
+
+**❌ Don't**
+- 가로 스와이프 네비게이션
+- 정밀 슬라이더 (1px 단위)
+- 드래그-앤-드롭
+
+```tsx
+// ❌
+<Slider min={0} max={100} step={1} />
+
+// ✅
+<Stack direction="row" gap="md">
+  <Button size="xl" label="-" onClick={dec} />
+  <Display value={value} />
+  <Button size="xl" label="+" onClick={inc} />
+</Stack>
+```
+
+---
+
+## Operational Context 3
+
+### 8. Status Persistence — 핵심 상태는 어디서나
+
+**왜.** 사용자는 끊임없이 "지금 이 기계 정상인가?"를 확인한다. 다른
+화면에 들어갔다는 이유로 핵심 상태(동작·연료·온도·압력·작업기 상태·
+자동 모드 ON·OFF)가 사라지면 사용자는 매번 메인 화면으로 돌아와야
+하고, 그 사이 이상이 발생해도 모른다.
+
+**✅ Do**
+- 모든 화면에 persistent status bar/strip
+- 핵심 지표 5~7개를 항상 노출
+- 이상 시 status bar에서 즉시 색·아이콘 변화
+
+**❌ Don't**
+- 화면 진입 시 status bar 사라짐
+- 설정 화면에서 "전체 화면 모드"로 status 가림
+- 모니터링 화면에서만 보이는 핵심 상태
+
+```tsx
+// ❌
+<Screen>
+  <SettingsForm />   {/* status bar 없음 */}
+</Screen>
+
+// ✅
+<Screen>
+  <PersistentStatusBar />
+  <SettingsForm />
+</Screen>
+```
+
+---
+
+### 9. Safety Override — 안전 알림은 모든 UI 위로
+
+**왜.** 충돌·과열·이상·인접 인원 감지 같은 안전 신호는 1초의 지연도
+용납되지 않는다. Toast로 띄우면 사용자가 다른 곳을 보고 있다가
+놓친다. 시끄러운 환경에서 음성만으로는 부족하고, 진동만으로도 부족하다.
+세 채널을 동시에 써야 한다.
+
+**✅ Do**
+- 풀스크린 모달, 다른 모든 UI 차단
+- 시각 + 음성 + 햅틱 3중
+- 명시적 acknowledge 필요 (자동 사라짐 X)
+
+**❌ Don't**
+- Toast로 안전 알림
+- 자동 dismiss
+- 무시·접기 가능한 배너
+
+```tsx
+// ❌
+toast.error('인접 인원 감지')
+
+// ✅
+<SafetyOverrideModal
+  severity="critical"
+  visual={true}
+  audio={true}
+  haptic={true}
+  requireAck={true}
+>
+  인접 인원 감지 — 즉시 정지
+</SafetyOverrideModal>
+```
+
+---
+
+### 10. Resumable — 중단·재개 잦음
+
+**왜.** 작업은 외부 사유(연료·식사·구역 이동)로 자주 끊긴다. 사용자가
+"처음부터 다시" 하도록 강요하면 매번 5~10분의 재설정이 누적되어 하루
+수십 분의 시간이 사라진다. UI는 마지막 상태를 기억하고, 재진입 시 그
+지점부터 이어가게 해야 한다.
+
+**✅ Do**
+- 진행률·모드·미완료 입력 보존 (로컬 + 디바이스 영속화)
+- 재진입 시 마지막 화면·마지막 단계로 자동 복귀
+- 명시적 "처음부터" 버튼은 별도 (한 번 더 confirm)
+
+**❌ Don't**
+- 새로고침 시 전체 초기화
+- 미완료 폼이 사라짐
+- 작업 중 모달이 외부 사유로 닫히면 다시 1단계부터
+
+```tsx
+// ❌
+const [step, setStep] = useState(1)  // 메모리에만
+
+// ✅
+const [step, setStep] = usePersistedState('workflow.step', 1)
+useEffect(() => {
+  if (step > 1) showResumeBanner()
+}, [])
+```


### PR DESCRIPTION
## 요약

SeamOS CustomUI 를 **React 18 + TypeScript + `@seamos/ads`** 로 짜기 위한 새 스킬 `seamos-customui-react` 신설.
기존 `seamos-customui-client` 는 통신 layer 로 그대로 유지되며, 본 스킬은 UI layer 를 책임진다.

## 핵심 결정

- **사용자 경험 원칙 10개** — Core 7 (Easy & Safe / Glanceability + 즉시 응답 / Consistency / Simplicity in Content / One Thing Per Screen / Easy to Answer 3초 / Tap & Scroll) + Operational Context 3 (Status Persistence / Safety Override / Resumable). 운영 중 기계 위 UI 라는 특수 환경 제약(진동·흔들림, 직사광·저조도, 장갑, 한 손 조작, 수~수십 시간 연속 작업)에서 역산.
- **ADS 사용은 정보 안내만** — Detachment 금지·토큰만·접근성 default 같은 강한 규약은 ADS 자체 문서 영역으로 위임. MCP 도구(`list_components` / `search_components` / `get_component`) 와 토큰 카테고리(color / spacing / typography / shadow / radius / motion) 안내만.
- **Flat / Compound API 위계 강제 X** — MCP 가 알려주는 권장 패턴을 그대로.
- **통신 layer 는 `seamos-customui-client` 로 cross-reference** — 본 스킬은 그 vanilla helper 를 React hook (`useApiBase` / `useTopic` / `usePublish` / `useExternalApi`) 으로 감싸 쓰는 패턴만 `references/react-patterns.md` 에 제공.

## 신규 파일 (5개, 총 1,095줄)

| File | Lines |
|---|---|
| `skills/seamos-customui-react/SKILL.md` | 196 |
| `skills/seamos-customui-react/references/ux-principles.md` | 317 |
| `skills/seamos-customui-react/references/ux-anti-patterns.md` | 182 |
| `skills/seamos-customui-react/references/ads-tokens.md` | 120 |
| `skills/seamos-customui-react/references/react-patterns.md` | 280 |

## 의도적 미수행

- `CHANGELOG.md` / `.claude-plugin/plugin.json` version bump — 사용자 결정에 따라 미실시
- `README.md` 스킬 카탈로그 업데이트 — 현 README 가 stale (`seamos-customui-client` / `edit-plugins` / `run-app` 도 누락, badge `skills-7` 이 실제 11개 스킬과 불일치) → **별도 PR 로 일괄 정비 예정**

## Test plan

- [ ] 스킬 트리거 — Claude Code 에서 "CustomUI 에 버튼 추가해줘" 같은 자연어로 본 스킬이 자동 로드되는지 확인
- [ ] `references/react-patterns.md` 의 hook 코드가 `seamos-customui-client` 의 vanilla helper 와 의미적으로 일치하는지 spot check
- [ ] 도메인 단어(농기계 / 건설기계 등) 직접 언급 0건 확인 — `grep -rE "농기계|건설기계|트랙터|굴착기" skills/seamos-customui-react/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)