### PR TITLE
docs: v0.7.2 — migration note for stale sdm_* userConfig keys

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "seamos-everywhere",
       "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "AGMO-Inc"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.7.2] — 2026-05-07
+
+Documentation patch: surface a migration step that the v0.7.1 release notes left implicit. Users who upgraded across the v0.6.0 (`sdm_*` → `seamos_*` rename) and v0.7.1 (OAuth) boundaries from a v0.5.x install carry stale `pluginConfigs` keys in `~/.claude/settings.json`. The plugin substitutes those keys via `${user_config.<name>}`; under v0.7+ the new `seamos_api_url` resolves to an empty string, so `${user_config.seamos_api_url}/mcp` collapses to a bare `/mcp` and the marketplace MCP server fails to connect on startup.
+
+### Added
+- **Migration note in `README.md` and CHANGELOG `[0.7.1]` cross-reference** — explicit instruction to rename or remove stale `sdm_api_url` / `sdm_api_key` (and any other `sdm_*` userConfig key) entries in `~/.claude/settings.json` after upgrading. The `seamos_api_url` value should be kept; `seamos_api_key` should not be added (no longer read by the plugin).
+
+### Why
+A user upgrading directly from v0.5.x to v0.7.1 hit a confusing failure mode: the marketplace MCP server appeared registered but every call failed with a malformed URL. Root cause was the stale userConfig key — the plugin had no way to surface this because `${user_config.X}` substitution returns empty string instead of erroring on unknown keys. Documenting the cleanup step closes the gap until Claude Code itself either errors on missing `userConfig` references or migrates legacy keys.
+
+### Migration (across v0.5.x → v0.7+)
+1. Open `~/.claude/settings.json`.
+2. Under `pluginConfigs.seamos-everywhere@seamos-plugins.options`, replace any `sdm_api_url` / `sdm_api_key` entry with `seamos_api_url` only — keep just the URL value:
+   ```json
+   "pluginConfigs": {
+     "seamos-everywhere@seamos-plugins": {
+       "options": {
+         "seamos_api_url": "https://dev.marketplace-api.seamos.io"
+       }
+     }
+   }
+   ```
+3. Restart Claude Code. The first marketplace MCP call opens a browser for one-time SeamOS OAuth login.
+
 ## [0.7.1] — 2026-05-06
 
 Marketplace authentication switches from a static `X-API-Key` header to OAuth 2.1 (PKCE). MCP calls go through Claude Code's standard HTTP MCP client, which receives an RFC 9728 protected-resource-metadata challenge and runs OAuth discovery → browser login → token cache automatically. Multipart uploads use a one-time `ut_*` token returned in the `create_app` / `update_app` MCP responses, sent as `Authorization: Bearer` (5-minute TTL, single-use, bound to the appId). User-side change is minimal — a one-time browser login on the first MCP call, fully automatic afterward.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Claude Code plugin for the SeamOS AI Native developer ecosystem**
 
-[![Version](https://img.shields.io/badge/version-0.7.1-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
+[![Version](https://img.shields.io/badge/version-0.7.2-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
 [![Skills](https://img.shields.io/badge/skills-12-orange.svg)](#skills)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 [![Org](https://img.shields.io/badge/org-AGMO--Inc-green.svg)](https://github.com/AGMO-Inc)
@@ -53,6 +53,8 @@ After installation, configure the marketplace endpoint:
 | `seamos_api_url` | SeamOS API base URL (e.g., `https://dev.marketplace-api.seamos.io`) |
 
 The first marketplace MCP call (e.g., `list_apps`, `create_app`) triggers Claude Code's standard OAuth (PKCE) flow — a browser opens, you sign in to SeamOS once, and the access token is cached locally. Multipart uploads (`upload-app`, `update-app`) additionally use a one-time `ut_*` token issued per request by the backend.
+
+> **Upgrading from v0.5.x or v0.6.x?** Open `~/.claude/settings.json` and rename any stale `sdm_api_url` / `sdm_api_key` (and other `sdm_*`) entries under `pluginConfigs.seamos-everywhere@seamos-plugins.options` to `seamos_api_url` only — keep the URL value, do NOT add `seamos_api_key` (no longer used). Without this, `${user_config.seamos_api_url}` substitutes to empty and the marketplace URL collapses to `/mcp`.
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation patch for a confusing failure mode discovered after v0.7.1 release.

A user upgrading directly from v0.5.x to v0.7.1 sees the marketplace MCP server "registered" in `/mcp` but every call fails with a malformed URL like `/mcp` (no host). Root cause: `~/.claude/settings.json` carries a stale `pluginConfigs` entry from before the v0.6.0 `sdm_*` → `seamos_*` rename. Under v0.7+ the new `seamos_api_url` substitutes to empty string, collapsing `${user_config.seamos_api_url}/mcp` into a bare `/mcp`.

The plugin cannot surface this — Claude Code does not error on unknown `${user_config.X}`. So the cleanup step is documented explicitly.

## What's in this PR

- `README.md` Configuration section gains a one-paragraph upgrade note pointing at `~/.claude/settings.json`.
- `CHANGELOG.md` `[0.7.2]` entry mirrors the same migration step with a copy-paste-ready settings snippet.
- `plugin.json`, `marketplace.json`, README badge: version bumped 0.7.1 → 0.7.2.

No code changes. Pure documentation.

## Migration step (for users)

Open `~/.claude/settings.json`, find:

```json
"pluginConfigs": {
  "seamos-everywhere@seamos-plugins": {
    "options": {
      "sdm_api_url": "https://...",
      "sdm_api_key": "..."
    }
  }
}
```

Replace with:

```json
"pluginConfigs": {
  "seamos-everywhere@seamos-plugins": {
    "options": {
      "seamos_api_url": "https://dev.marketplace-api.seamos.io"
    }
  }
}
```

Restart Claude Code. The first marketplace MCP call opens a browser for one-time SeamOS OAuth login.

## Test plan

- [x] JSON validity — `plugin.json`, `marketplace.json`
- [x] Diff stat — 4 files changed, +29 / −3
- [ ] After merge: confirm marketplace picks up v0.7.2 in plugin cache and the README badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
