### PR TITLE
v0.7.2 — fix oauth.clientId + stale userConfig migration note

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "seamos-everywhere",
       "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "AGMO-Inc"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.7.2] — 2026-05-07
+
+Two follow-ups to v0.7.1: a missing OAuth client declaration that prevented the marketplace handshake from completing, plus a migration note for users coming directly from a v0.5.x install.
+
+### Fixed
+- **`mcpServers.seamos-marketplace.oauth.clientId` declared as `"sdm-mcp"`** in `mcp-servers.json`. Claude Code's HTTP MCP OAuth client needs an explicit `client_id` matching the SeamOS Keycloak `sdm-mcp` confidential client (PKCE, loopback redirect; see AGMO-Inc/agmo-auth-system). Without it, the OAuth handshake on the first marketplace MCP call cannot complete because the authorization server has no dynamic-registration path enabled. v0.7.1 shipped without this field, so the brand-new OAuth flow it introduced wouldn't actually start for end users.
+
+### Added
+- **Migration note in `README.md` and CHANGELOG** — explicit instruction to rename or remove stale `sdm_api_url` / `sdm_api_key` (and any other `sdm_*` userConfig key) entries in `~/.claude/settings.json` after upgrading. The `seamos_api_url` value should be kept; `seamos_api_key` should not be added (no longer read by the plugin).
+
+### Why
+A user upgrading directly from v0.5.x to v0.7.1 hit a confusing chain: first the marketplace MCP server appeared registered but every call failed with a malformed URL (stale userConfig key — `${user_config.seamos_api_url}/mcp` collapsed to `/mcp` because the new key didn't exist), then once that was fixed the OAuth handshake itself silently failed (no `client_id` declared). The plugin had no way to surface either failure on its own — `${user_config.X}` substitution returns an empty string for unknown keys, and Claude Code's OAuth client can't infer the right `client_id` without dynamic registration support. v0.7.2 closes both gaps.
+
+### Migration (across v0.5.x → v0.7+)
+1. Open `~/.claude/settings.json`.
+2. Under `pluginConfigs.seamos-everywhere@seamos-plugins.options`, replace any `sdm_api_url` / `sdm_api_key` entry with `seamos_api_url` only — keep just the URL value:
+   ```json
+   "pluginConfigs": {
+     "seamos-everywhere@seamos-plugins": {
+       "options": {
+         "seamos_api_url": "https://dev.marketplace-api.seamos.io"
+       }
+     }
+   }
+   ```
+3. Restart Claude Code. The first marketplace MCP call opens a browser for one-time SeamOS OAuth login.
+
 ## [0.7.1] — 2026-05-06
 
 Marketplace authentication switches from a static `X-API-Key` header to OAuth 2.1 (PKCE). MCP calls go through Claude Code's standard HTTP MCP client, which receives an RFC 9728 protected-resource-metadata challenge and runs OAuth discovery → browser login → token cache automatically. Multipart uploads use a one-time `ut_*` token returned in the `create_app` / `update_app` MCP responses, sent as `Authorization: Bearer` (5-minute TTL, single-use, bound to the appId). User-side change is minimal — a one-time browser login on the first MCP call, fully automatic afterward.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Claude Code plugin for the SeamOS AI Native developer ecosystem**
 
-[![Version](https://img.shields.io/badge/version-0.7.1-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
+[![Version](https://img.shields.io/badge/version-0.7.2-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
 [![Skills](https://img.shields.io/badge/skills-12-orange.svg)](#skills)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 [![Org](https://img.shields.io/badge/org-AGMO--Inc-green.svg)](https://github.com/AGMO-Inc)
@@ -53,6 +53,8 @@ After installation, configure the marketplace endpoint:
 | `seamos_api_url` | SeamOS API base URL (e.g., `https://dev.marketplace-api.seamos.io`) |
 
 The first marketplace MCP call (e.g., `list_apps`, `create_app`) triggers Claude Code's standard OAuth (PKCE) flow — a browser opens, you sign in to SeamOS once, and the access token is cached locally. Multipart uploads (`upload-app`, `update-app`) additionally use a one-time `ut_*` token issued per request by the backend.
+
+> **Upgrading from v0.5.x or v0.6.x?** Open `~/.claude/settings.json` and rename any stale `sdm_api_url` / `sdm_api_key` (and other `sdm_*`) entries under `pluginConfigs.seamos-everywhere@seamos-plugins.options` to `seamos_api_url` only — keep the URL value, do NOT add `seamos_api_key` (no longer used). Without this, `${user_config.seamos_api_url}` substitutes to empty and the marketplace URL collapses to `/mcp`.
 
 ---
 

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "seamos-marketplace": {
       "type": "http",
-      "url": "${user_config.seamos_api_url}/mcp"
+      "url": "${user_config.seamos_api_url}/mcp",
+      "oauth": {
+        "clientId": "sdm-mcp"
+      }
     },
     "ads": {
       "type": "http",


### PR DESCRIPTION
## Summary

Two follow-ups to v0.7.1 that surfaced after release:

### Fix — `oauth.clientId` declaration (the critical one)

`v0.7.1` introduced the OAuth (PKCE) flow for the marketplace MCP server but shipped without declaring `mcpServers.seamos-marketplace.oauth.clientId`. Without it, Claude Code's HTTP MCP OAuth client has no `client_id` to send to Keycloak — and the SeamOS realm has no dynamic-registration path enabled — so the first marketplace MCP call's OAuth handshake cannot start at all. The brand-new auth flow was effectively broken for end users.

This PR sets `oauth.clientId: "sdm-mcp"` in `mcp-servers.json` to match the confidential client already registered in `AGMO-Inc/agmo-auth-system` (PKCE, loopback redirect).

```diff
 {
   "mcpServers": {
     "seamos-marketplace": {
       "type": "http",
-      "url": "${user_config.seamos_api_url}/mcp"
+      "url": "${user_config.seamos_api_url}/mcp",
+      "oauth": {
+        "clientId": "sdm-mcp"
+      }
     }
   }
 }
```

### Docs — stale `sdm_*` userConfig migration note

A user upgrading directly from v0.5.x to v0.7.1 hits a separate, earlier failure: the marketplace MCP server appears registered but every call errors with a malformed URL like `/mcp` (no host). Root cause: `~/.claude/settings.json` carries a stale `pluginConfigs` entry from before the v0.6.0 `sdm_*` → `seamos_*` rename. Under v0.7+ the new `seamos_api_url` substitutes to an empty string, collapsing `${user_config.seamos_api_url}/mcp` into a bare `/mcp`. Claude Code does not error on unknown `${user_config.X}`, so the plugin cannot surface this on its own — it has to be documented.

This PR adds:
- `README.md` Configuration section: a one-paragraph upgrade note pointing at `~/.claude/settings.json`.
- `CHANGELOG.md` `[0.7.2]` entry mirrors the same migration steps with a copy-paste-ready settings snippet.

## Why two things in one PR

Both are necessary for a v0.5.x or v0.6.x user to actually reach a working OAuth handshake on v0.7+. The userConfig fix unblocks the URL; the `oauth.clientId` fix unblocks the handshake. Shipping the docs without the `clientId` fix would just trade one silent failure for another.

## Files changed

| File | Change |
|---|---|
| `mcp-servers.json` | Add `oauth.clientId: "sdm-mcp"` |
| `README.md` | Configuration section migration note + version badge → 0.7.2 |
| `CHANGELOG.md` | New `[0.7.2]` entry covering both fix + docs |
| `.claude-plugin/plugin.json` | version 0.7.1 → 0.7.2 |
| `.claude-plugin/marketplace.json` | version 0.7.1 → 0.7.2 |

5 files changed, +36 / −4. No code changes outside `mcp-servers.json`.

## Test plan

- [x] JSON validity — `mcp-servers.json`, `plugin.json`, `marketplace.json` all parse
- [x] `oauth.clientId` field declared correctly
- [ ] After merge: confirm marketplace picks up v0.7.2 in plugin cache
- [ ] On a fresh session: first `list_apps` call opens browser → SeamOS login → token cached → ✓ connected (the actual end-to-end OAuth handshake that v0.7.1 couldn't complete)

## Migration step (for v0.5.x / v0.6.x users)

Open `~/.claude/settings.json`. Under `pluginConfigs.seamos-everywhere@seamos-plugins.options`, rename the stale entry:

```json
{
  "pluginConfigs": {
    "seamos-everywhere@seamos-plugins": {
      "options": {
        "seamos_api_url": "https://dev.marketplace-api.seamos.io"
      }
    }
  }
}
```

Drop any `sdm_api_url`, `sdm_api_key`, or `seamos_api_key` entries — the first two are pre-rename, and `seamos_api_key` is no longer read by the plugin under OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
