### PR TITLE
docs: v0.7.6 — External API Server Communication 패턴 도큐먼트화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "seamos-everywhere",
       "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "author": {
         "name": "AGMO-Inc"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.7.6] — 2026-05-08
+
+**External API Server Communication 패턴 도큐먼트화.** 사용자가 SeamOS 앱(C++/Java)에서 외부 HTTPS API 를 호출하는 방법을 물었을 때, 스킬에는 — 공식 문서(https://docs.seamos.io/docs/4/5/4) 와 reference 구현(`external_api_test`, `cpp_deploy_test_19`) 모두 존재함에도 — 패턴이 전혀 들어 있지 않아 매번 raw 코드를 직접 읽고 재구성해야 했음. 이 갭을 메운다. 스킬 본체 코드 변경 없음 (문서 + 트리거 키워드 + cross-reference 만).
+
+### Added — External API Server Communication
+- **`skills/seamos-app-framework/references/usage-patterns/cpp.md`** — "External API Server Communication" 섹션 신설 (+299 lines). 두 패턴 풀 코드:
+  - **Pattern A — Sync HTTP `/extApi`**: `ExternalApiRequestManager` singleton + `std::promise`/`wait_for(10s)` + Poco `NevonexRoute` 핸들러. UI 가 동기 응답 기대하는 form submit / bulk fetch 용.
+  - **Pattern B — Async WebSocket `/socket`**: `WebSocketEndPoint::onWebSocketMessage` 에서 `endPoint` 필드 감지 → Cloud uploadData 디스패치 → `CloudDownloadListener` 가 `external_api_response` envelope 으로 broadcast. 실시간/concurrent/long-op 용.
+  - **단일 응답 핸들러**: `CloudDownloadListener::handleMessage` 가 `correlation-id` prefix(`HTTP*` vs `WS*`)로 두 패턴 분기.
+  - **Listener 등록**: `ApplicationMain::addCloudDownloadListener` (Cloud singleton 에 `addPropertyChangeListener`) + `addCustomUIListener` (`/extApi` Route + `/socket` WS).
+  - **Gotcha 5 개**: register-before-uploadData race, correlation-id 충돌, importance arg = 1 fixed, Pattern A 의 10 초 ceiling, D2D listener 빈 stub 은 의도적 (Cloud 코드 복사 금지).
+- **`skills/seamos-app-framework/references/usage-patterns/java.md`** — Java 동등 패턴 섹션 (+147 lines). C++ ⇄ Java 타입 매핑 표(`std::promise` ↔ `CompletableFuture`, `Json::Value` ↔ Gson `JsonObject`, `BaseRestService` 기반 라우트). Pattern A 풀 스켈레톤(`ExternalApiRequestManager` ConcurrentHashMap + `CompletableFuture.get(10, TimeUnit.SECONDS)`).
+- **`skills/seamos-customui-client/references/cloud-proxy.md`** — "How the backend dispatches the envelope" 섹션 추가 (+62 lines). 브라우저↔백엔드 envelope key rename 표(`endPoint`→`externalUrl`, `methodSelect`→`method`, `reqHeader`→`header`, `reqBody`→`msg`), 두 패턴 요약, "백엔드 의심 vs UI 의심" 트러블슈팅 표. 실제 backend 구현은 `seamos-app-framework` 로 cross-reference.
+
+### Changed — Trigger keywords + cross-references
+- **`skills/seamos-app-framework/SKILL.md`** — description 에 "external API server communication" 추가, 트리거 9 개 추가(`external API`, `외부 API`, `cloud proxy`, `uploadData`, `extApi`, `CloudDownloadListener`, `correlation-id`, `외부 서버 호출`, `백엔드 외부 호출`). 패턴 표에 External API 행 추가. Step 1 Pattern Selection 에 외부 API 항목 추가.
+- **`skills/seamos-customui-client/SKILL.md`** — description 에 envelope key rename 명시(`endPoint → externalUrl` 등) — 백엔드 측 키 이름과 UI 측 키 이름이 다른 점이 디버깅의 첫 함정인데 description 에 안 써 있어서 cloud-proxy.md 까지 들어가야 알 수 있던 부분.
+- **`skills/seamos-plugins/references/usage-patterns/cpp.md` / `java.md`** — Platform Service Methods 의 `Cloud::uploadData(data, ?)` 두번째 인자에 주석 추가: **importance(중요도). 보통 1 로 픽스해서 사용** (사용자 확인 사항). 외부 API 호출은 직접 HTTP 클라이언트가 아니라 Cloud 채널로 가야 한다는 원칙 + `seamos-app-framework` 외부 API 섹션으로 cross-ref 추가.
+
+### Why now (사용자 학습 동기)
+사용자가 `cpp_deploy_test_19` 의 `WebSocketEndPointImpl.cpp` / `CloudDownloadListenerImpl.cpp` 와 공식 문서를 함께 보여주며 "이 패턴이 스킬에 왜 없냐"고 짚어줘서 갭을 인지. 다음 SeamOS 앱 만들 때 Claude 가 처음부터 올바른 패턴(특히 `correlation-id` prefix 분기, importance arg, envelope key rename)을 생성하도록 SSOT 를 옮긴다.
+
+### Notes
+- 코드 변경 없음 — 스킬 문서/메타데이터만. plugin install/setup/upload/build 동작 회귀 위험 없음.
+- 레퍼런스 구현 두 개 모두 명시: `external_api_test` (두 패턴 다), `cpp_deploy_test_19` (WebSocket-only 변종) — 사용자가 어느 프로젝트 보고 따라 만들지 헷갈리지 않게.
+
 ## [0.7.5] — 2026-05-07
 
 **Zero-config plugin install.** 0.7.4 까지 사용자가 plugin install 직후 `/plugin config seamos-everywhere` 로 `seamos_api_url` 을 직접 입력해야 첫 MCP 호출이 동작했다. 이는 일반 사용자에게 마찰이고, 0.7.1 워크스루에서도 외부 의존(B2 — Claude Code 본체가 install 시 userConfig prompt 를 안 띄우는 문제) 을 우회 못 해 STATUS_WARN 안내로만 처리해뒀던 부분. 0.7.5 는 마찰 자체를 제거 — plugin 의 `mcp-servers.json` 이 dev 마켓플레이스 URL 을 직접 박아두고, `userConfig.seamos_api_url` 정의는 통째 제거한다. install 즉시 OAuth 기반 마켓플레이스 도구가 동작.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Claude Code plugin for the SeamOS AI Native developer ecosystem**
 
-[![Version](https://img.shields.io/badge/version-0.7.5-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
+[![Version](https://img.shields.io/badge/version-0.7.6-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
 [![Skills](https://img.shields.io/badge/skills-12-orange.svg)](#skills)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 [![Org](https://img.shields.io/badge/org-AGMO--Inc-green.svg)](https://github.com/AGMO-Inc)

--- a/skills/seamos-app-framework/SKILL.md
+++ b/skills/seamos-app-framework/SKILL.md
@@ -2,13 +2,16 @@
 name: seamos-app-framework
 description: >
   SeamOS (NEVONEX) app framework code generation guide for REST API, WebSocket, DB persistence,
-  and feature lifecycle patterns. Supports Java and C++ projects.
+  feature lifecycle, and external API server communication patterns. Supports Java and C++ projects.
   Use when developing SeamOS apps that need HTTP endpoints, WebSocket communication,
-  database storage, or lifecycle management.
+  database storage, lifecycle management, or outbound calls to external/cloud APIs
+  (which must route through the Cloud plugin — apps cannot open external HTTP sockets directly).
   Triggers: "REST", "API", "endpoint", "라우트", "route", "WebSocket", "소켓", "socket",
   "DB", "database", "데이터베이스", "영속성", "persistence", "H2", "SQLite",
   "lifecycle", "라이프사이클", "CRUD", "테이블", "table", "repository",
-  "saveToDisk", "persistToDisk", "handleFeatureStart".
+  "saveToDisk", "persistToDisk", "handleFeatureStart",
+  "external API", "외부 API", "cloud proxy", "uploadData", "extApi",
+  "CloudDownloadListener", "correlation-id", "외부 서버 호출", "백엔드 외부 호출".
 ---
 
 # SeamOS App Framework
@@ -30,6 +33,7 @@ Guide for developing SeamOS apps with REST APIs, WebSocket communication, databa
 | WebSocket | Jetty @WebSocket | WebSocketRouteFactory | Real-time communication |
 | DB Persistence | H2 + FCALFileProvider | SQLite + FileProvider | Data storage with container survival |
 | Feature Lifecycle | AbstractFeatureNotification | FeatureManagerListener + IgnitionStateListener | App start/stop hooks |
+| External API | `CompletableFuture` + Cloud + CloudDownloadListener | `std::promise` + Cloud + CloudDownloadListener | Outbound HTTPS to cloud / marketplace / 3rd-party |
 
 ## Workflow
 
@@ -40,6 +44,7 @@ Determine which pattern the user needs:
 - **WebSocket** — Real-time bidirectional communication between app and client
 - **DB Persistence** — Structured data storage that survives NEVONEX container restarts
 - **Feature Lifecycle** — Hooks for app start, stop, and ignition state changes
+- **External API Server Communication** — Outbound calls from the app to non-local URLs (cloud APIs, marketplace, 3rd-party). Must route through the Cloud plugin's `uploadData` + `CloudDownloadListener` channel; direct HTTP sockets are not supported. Two sub-patterns: sync (`/extApi`, `HTTP*` correlation prefix, `std::promise`/`CompletableFuture` + 10 s wait) and async (`/socket`, `WS*` prefix, push back over WebSocket).
 
 ### Step 2: Language Detection
 

--- a/skills/seamos-app-framework/references/usage-patterns/cpp.md
+++ b/skills/seamos-app-framework/references/usage-patterns/cpp.md
@@ -104,6 +104,305 @@ customui::UIWebServiceProvider::getInstance()->registerWebsocketRoute("/socket",
 > Browser-side counterpart (port discovery, frame protocol, cloud proxy):
 > see the `seamos-customui-client` skill.
 
+## External API Server Communication
+
+> Authoritative spec: https://docs.seamos.io/docs/4/5/4
+>
+> Reference implementations: `external_api_test` (full — both patterns) and
+> `cpp_deploy_test_19` (WebSocket-only variant).
+
+### Why the indirect path
+
+SeamOS apps **do not open TCP/HTTP sockets to external servers directly**.
+Every outbound call to a non-local URL flows through the Cloud plugin, which
+the platform forwards to the configured external server. The response comes
+back through `CloudDownloadListener::handleMessage`. The app matches request
+to response by `correlation-id`.
+
+This isn't an arbitrary detour — it's where the platform attaches:
+- Authentication and TLS / certificate validation
+- Network-policy enforcement (the device's egress is locked down)
+- Audit logging
+
+App code therefore never sees the upstream's TCP endpoint, never handles
+TLS, and never embeds external credentials. If you want a direct outbound
+HTTP from C++, you'd need to link Poco/Boost.Beast yourself and you'd lose
+all of the above — almost always wrong.
+
+### Two patterns: pick by how the UI waits
+
+| Pattern | UI entry | correlation-id prefix | App waits via | When to use |
+|---------|----------|-----------------------|---------------|-------------|
+| **A. Sync HTTP proxy** | `POST /extApi` | `HTTP*` | `std::promise` + `wait_for(10s)` | Form submit, bulk fetch, UI expects one synchronous return |
+| **B. Async WebSocket** | `ws://.../socket` | `WS*` | None — push back via WS | Real-time, multiple concurrent calls, long ops |
+
+The `correlation-id` prefix is the **single dispatch signal** in
+`CloudDownloadListener::handleMessage`. Honour it when generating ids and
+the same listener handles both patterns.
+
+### Envelope key rename (UI ⇄ Cloud proxy)
+
+The UI speaks browser-friendly keys; the Cloud channel speaks proxy-contract
+keys. The translation is the app's job:
+
+| UI sends (browser) | App forwards (Cloud proxy) |
+|--------------------|----------------------------|
+| `endPoint`         | `externalUrl`              |
+| `methodSelect`     | `method`                   |
+| `reqHeader`        | `header`                   |
+| `reqBody`          | `msg`                      |
+| `correlation-id` (optional) | `correlation-id` (generated if absent) |
+
+### Request envelope struct
+
+A small carrier struct keeps both patterns honest:
+
+```cpp
+class ExternalApiRequest {
+public:
+    std::string endPoint;     // External URL
+    std::string method;       // GET, POST, ...
+    Json::Value headerJson;   // Headers as JSON
+    Json::Value bodyJson;     // Request body as JSON
+};
+```
+
+### Pattern A — Sync HTTP `/extApi`
+
+Two pieces: a singleton that parks `std::promise`s by id, and a
+`NevonexRoute` that registers the promise, fires the request, and blocks
+on the future.
+
+**Correlation manager (singleton):**
+```cpp
+class ExternalApiRequestManager {
+public:
+    static ExternalApiRequestManager* getInstance();
+
+    void addPendingRequest(
+        const std::string& correlationId,
+        std::shared_ptr<std::promise<std::string>> promiseObj);
+
+    void notifyResponse(
+        const std::string& correlationId,
+        const std::string& responseBody);
+
+    void removeRequest(const std::string& correlationId);
+
+private:
+    std::mutex _mutex;
+    std::map<std::string, std::shared_ptr<std::promise<std::string>>>
+            _pendingRequests;
+};
+
+void ExternalApiRequestManager::notifyResponse(
+        const std::string& correlationId, const std::string& responseBody) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _pendingRequests.find(correlationId);
+    if (it != _pendingRequests.end()) {
+        try {
+            it->second->set_value(responseBody);
+        } catch (const std::future_error&) { /* already set */ }
+        _pendingRequests.erase(it);
+    }
+}
+```
+
+**HTTP route handler — POST `/extApi`:**
+```cpp
+void ExternalApiRoute::handlePost(
+        Poco::Net::HTTPServerRequest &req,
+        Poco::Net::HTTPServerResponse &response) {
+    // 1. Parse incoming UI body
+    Json::Value uiBody;
+    Json::CharReaderBuilder builder;
+    std::string errs;
+    auto stream = std::istringstream(
+        std::string(std::istreambuf_iterator<char>(req.stream()), {}));
+    Json::parseFromStream(builder, stream, &uiBody, &errs);
+
+    // 2. Register a promise BEFORE firing — race-free
+    auto promise = std::make_shared<std::promise<std::string>>();
+    auto future  = promise->get_future();
+
+    long ts = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    std::string cid = "HTTP" + std::to_string(ts);
+    ExternalApiRequestManager::getInstance()->addPendingRequest(cid, promise);
+
+    // 3. Build proxy envelope (rename keys) and send via Cloud
+    Json::Value envelope;
+    envelope["correlation-id"] = cid;
+    envelope["externalUrl"]    = uiBody["endPoint"].asString();
+    envelope["method"]         = uiBody["methodSelect"].asString();
+    envelope["header"]         = uiBody["reqHeader"];
+    envelope["msg"]            = uiBody["reqBody"];
+
+    Json::StreamWriterBuilder writer;
+    std::string envelopeStr = Json::writeString(writer, envelope);
+    ::nevonex::cloud::Cloud::getInstance()->uploadData(envelopeStr, 1);
+    //                                                              ↑
+    //   Second arg is importance (priority). Convention: fixed at 1.
+
+    // 4. Wait up to 10 s
+    if (future.wait_for(std::chrono::seconds(10))
+            == std::future_status::ready) {
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+        response.setContentType("application/json");
+        response.set("Access-Control-Allow-Origin", "*");
+        std::ostream &out = response.send();
+        out << future.get();
+        out.flush();
+    } else {
+        ExternalApiRequestManager::getInstance()->removeRequest(cid);
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_GATEWAY_TIMEOUT);
+        std::ostream &out = response.send();
+        out << R"({"status":504,"msg":"Gateway Timeout: No response."})";
+        out.flush();
+    }
+}
+```
+
+> The 10 s timeout is the reference value — adjust per app, but cap it.
+> A blocked HTTP thread in the SeamOS app starves other requests.
+
+### Pattern B — Async WebSocket `/socket`
+
+When the UI already has a WebSocket open, dispatch through it and push the
+response back asynchronously. No promise/future, no thread blocking.
+
+```cpp
+void WebSocketEndPoint::onWebSocketMessage(const std::string &message) {
+    // Parse UI message; if it's an external-API request, route it.
+    Json::Value root;
+    Json::CharReaderBuilder rb;
+    std::string errs;
+    std::unique_ptr<Json::CharReader> reader(rb.newCharReader());
+    if (!reader->parse(message.data(),
+                       message.data() + message.size(),
+                       &root, &errs)) return;
+
+    if (!root.isMember("endPoint")) {
+        // Not an external API call — handle other UI frames (publish, etc.)
+        return;
+    }
+
+    long ts = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    std::string cid = root.get("correlation-id", "").asString();
+    if (cid.empty()) cid = "WS" + std::to_string(ts);
+
+    Json::Value envelope;
+    envelope["correlation-id"] = cid;
+    envelope["externalUrl"]    = root["endPoint"].asString();
+    envelope["method"]         = root["methodSelect"].asString();
+    envelope["header"]         = root["reqHeader"];
+    envelope["msg"]            = root["reqBody"];
+
+    Json::StreamWriterBuilder writer;
+    std::string envelopeStr = Json::writeString(writer, envelope);
+    ::nevonex::cloud::Cloud::getInstance()->uploadData(envelopeStr, 1);
+    // Response will arrive in CloudDownloadListener and be pushed to the WS.
+}
+```
+
+### CloudDownloadListener — the single response handler
+
+The same listener serves both patterns. Disambiguate by `correlation-id`
+prefix. Pattern A resolves the parked promise; Pattern B re-wraps and pushes
+to the UI WebSocket as `external_api_response`.
+
+```cpp
+void CloudDownloadListener::handleMessage(const std::string &_content) {
+    Json::Value response;
+    Json::CharReaderBuilder builder;
+    std::string errs;
+    auto stream = std::istringstream(_content);
+    if (!Json::parseFromStream(builder, stream, &response, &errs)) {
+        NEVONEX_LOG(SeverityLevel::warning)
+                << "[CloudDownload] JSON parse failed: " << errs;
+        return;
+    }
+    if (!response.isMember("correlation-id")
+            || !response["correlation-id"].isString()) return;
+
+    const std::string cid = response["correlation-id"].asString();
+
+    if (cid.find("HTTP") != std::string::npos) {
+        // Pattern A: wake up ExternalApiRoute::handlePost
+        ExternalApiRequestManager::getInstance()
+                ->notifyResponse(cid, _content);
+        return;
+    }
+
+    if (cid.find("WS") != std::string::npos) {
+        // Pattern B: re-wrap as external_api_response and broadcast
+        Json::Value envelope;
+        envelope["type"]           = "external_api_response";
+        envelope["correlation-id"] = cid;
+        envelope["data"]           = response.get("data", Json::Value());
+
+        Json::StreamWriterBuilder wb; wb["indentation"] = "";
+        auto ws = ::AppMain::web::WebSocketEndPoint::getInstance();
+        if (ws) ws->publishMessage(Json::writeString(wb, envelope));
+    }
+}
+```
+
+> The outgoing UI envelope (`{ type: "external_api_response", ... }`) is
+> what the browser-side dispatcher matches on. See the browser dispatch
+> skeleton in `seamos-customui-client` → ws-protocol.md.
+
+### Listener registration (in `addCustomUIListener` / lifecycle)
+
+```cpp
+void ApplicationMain::addCloudDownloadListener() {
+    using namespace ::nevonex::cloud;
+    auto *listener = new CloudDownloadListener();
+    listener->setMainController(getMainController());
+    Cloud::getInstance()->addPropertyChangeListener(listener);
+    //                    ↑
+    // Cloud is a singleton; treat it as a long-lived global. The listener
+    // outlives any single request — it's the demux for ALL cloud responses.
+}
+
+void ApplicationMain::addCustomUIListener() {
+    // Pattern A — HTTP proxy route
+    auto extFactory = std::make_shared<ExternalApiRouteFactory>();
+    extFactory->setMainController(getMainController());
+    customui::UIWebServiceProvider::getInstance()
+            ->registerRoute("/extApi", extFactory);
+
+    // Pattern B — WebSocket route (also handles /publish frames etc.)
+    auto ws = WebSocketEndPoint::getInstance();
+    ws->setMainController(getMainController());
+    customui::UIWebServiceProvider::getInstance()
+            ->registerWebsocketRoute("/socket", ws);
+}
+```
+
+### Common gotchas
+
+- **Register the promise BEFORE calling `uploadData`** in Pattern A. If the
+  cloud responds faster than `addPendingRequest` runs, `notifyResponse`
+  silently drops the message — there's no parked entry to resolve.
+- **`correlation-id` must be unique across BOTH patterns at any moment.**
+  The prefix is the dispatch key, but the full id (prefix + epoch) must
+  also be unique. `HTTP{ms}` + `WS{ms}` collisions across patterns at the
+  same millisecond are theoretically possible — add a counter if you fire
+  many requests in tight loops.
+- **`Cloud::uploadData(payload, 1)` second arg is importance/priority,
+  conventionally fixed at 1.** The Cloud plugin uses it to bucket queued
+  outbound traffic; varying it without a deliberate reason is noise.
+- **Don't use Pattern A for streaming or long-poll responses.** The 10 s
+  timeout fires and the response, when it eventually arrives, becomes an
+  orphan that `notifyResponse` drops because `removeRequest` already ran.
+  Use Pattern B and let the UI manage its own timeout.
+- **Device2Device download/receive looks similar but is a separate channel
+  — its `handleMessage` is intentionally left unimplemented in the
+  reference projects.** Don't copy the Cloud dispatch logic into the D2D
+  listener unless you actually need D2D-driven responses.
+
 ## DB Persistence
 
 C++ SQLite 의 working DB 는 `./db/<name>.db` 에 두며 빌드 시 제외된다. 디바이스 영속 DB 는 `disk/<feature>/runtime.db` 와 같이 `disk/<feature>/...` 하위에 위치하며 디바이스 측에서 런타임에 생성/유지한다 — 빌드 산출물(FIF) 에 포함되지 않는다. 앱이 의도적으로 동봉하는 시드 데이터(예: 초기 카탈로그 SQLite dump 또는 JSON) 는 `disk/seed/...` 하위에 두면 allowlist 정책으로 패키징되어 첫 부팅 시 디바이스로 복사된다.

--- a/skills/seamos-app-framework/references/usage-patterns/java.md
+++ b/skills/seamos-app-framework/references/usage-patterns/java.md
@@ -96,6 +96,153 @@ UIWebServiceProvider.getInstance().openWebsocket("/socket", UIWebsocketEndPoint.
 > Browser-side counterpart (port discovery, frame protocol, cloud proxy):
 > see the `seamos-customui-client` skill.
 
+## External API Server Communication
+
+> Authoritative spec: https://docs.seamos.io/docs/4/5/4
+>
+> The reference implementations are C++ (`external_api_test`,
+> `cpp_deploy_test_19`). The architectural rules below apply identically to
+> Java — only the type names change. When generating Java code, mirror the
+> C++ patterns in `cpp.md` § External API Server Communication and adapt as
+> noted here.
+
+### Same indirect-path rule
+
+SeamOS Java apps **do not open external HTTP sockets directly**. Outbound
+traffic goes through the Cloud plugin; responses come back via the Cloud
+download listener. The platform owns auth, TLS, network policy, and audit
+logging.
+
+### Two patterns (same as C++)
+
+| Pattern | UI entry | correlation-id prefix | App waits via | When to use |
+|---------|----------|-----------------------|---------------|-------------|
+| **A. Sync HTTP proxy** | `POST /extApi` | `HTTP*` | `CompletableFuture<String>` + `get(10, TimeUnit.SECONDS)` | UI expects synchronous return |
+| **B. Async WebSocket** | `ws://.../socket` | `WS*` | None — push back over WS | Real-time / concurrent / long ops |
+
+### Java equivalents of the key types
+
+| C++ | Java |
+|-----|------|
+| `ExternalApiRequestManager` (singleton, `std::map<id, std::promise>`) | Singleton with `ConcurrentHashMap<String, CompletableFuture<String>>` |
+| `std::promise<std::string>` / `wait_for` | `CompletableFuture<String>` + `get(10, TimeUnit.SECONDS)` |
+| `Json::Value` envelope + `Json::writeString` | `JsonObject` (Gson) + `gson.toJson(...)` |
+| `Cloud::getInstance()->uploadData(payload, 1)` | `Cloud.getInstance().uploadData(payloadString, 1)` — second arg is importance/priority, conventionally fixed at 1 |
+| `CloudDownloadListener::handleMessage` | `CloudDownloadListener#handleMessage(String)` registered via `Cloud.getInstance().addPropertyChangeListener(...)` |
+| `WebSocketEndPoint::onWebSocketMessage` | `@OnWebSocketMessage public void message(...)` on `UIWebsocketEndPoint` |
+| HTTP route `ExternalApiRoute` | `BaseRestService` subclass `ExternalApiService`, registered via `UIWebServiceProvider.getInstance().registerPostService("extApi", ...)` |
+
+### Envelope key rename (identical to C++)
+
+```
+UI sends            App forwards
+─────────           ────────────
+endPoint        →   externalUrl
+methodSelect    →   method
+reqHeader       →   header
+reqBody         →   msg
+correlation-id  →   correlation-id (generate "HTTP{ms}" or "WS{ms}" if absent)
+```
+
+### Pattern A skeleton (Java)
+
+```java
+public class ExternalApiRequestManager {
+    private static final ExternalApiRequestManager INSTANCE = new ExternalApiRequestManager();
+    private final Map<String, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+
+    public static ExternalApiRequestManager getInstance() { return INSTANCE; }
+
+    public void addPending(String cid, CompletableFuture<String> f) { pending.put(cid, f); }
+    public void notifyResponse(String cid, String body) {
+        CompletableFuture<String> f = pending.remove(cid);
+        if (f != null) f.complete(body);
+    }
+    public void remove(String cid) { pending.remove(cid); }
+}
+```
+
+```java
+public class ExternalApiService extends BaseRestService {
+    @Override
+    public Object processService(Request request, Response response) {
+        JsonObject ui = parseBody(request);
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        String cid = "HTTP" + System.currentTimeMillis();
+        ExternalApiRequestManager.getInstance().addPending(cid, future);
+
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty("correlation-id", cid);
+        envelope.addProperty("externalUrl", ui.get("endPoint").getAsString());
+        envelope.addProperty("method",      ui.get("methodSelect").getAsString());
+        envelope.add("header", ui.get("reqHeader"));
+        envelope.add("msg",    ui.get("reqBody"));
+
+        Cloud.getInstance().uploadData(new Gson().toJson(envelope), 1);
+        //                                                          ↑
+        //  Importance (priority). Convention: fixed at 1.
+
+        try {
+            response.type("application/json");
+            return future.get(10, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            ExternalApiRequestManager.getInstance().remove(cid);
+            response.status(504);
+            return "{\"status\":504,\"msg\":\"Gateway Timeout: No response.\"}";
+        } catch (Exception e) {
+            response.status(500);
+            return errorResponse(e.getMessage());
+        }
+    }
+}
+```
+
+### CloudDownloadListener dispatch (Java)
+
+```java
+public class CloudDownloadListener implements PropertyChangeListener {
+    @Override
+    public void propertyChange(PropertyChangeEvent ev) {
+        if (!"download".equals(ev.getPropertyName())) return;
+        String content = ev.getNewValue().toString();
+        JsonObject root = JsonParser.parseString(content).getAsJsonObject();
+        if (!root.has("correlation-id")) return;
+        String cid = root.get("correlation-id").getAsString();
+
+        if (cid.startsWith("HTTP")) {
+            ExternalApiRequestManager.getInstance().notifyResponse(cid, content);
+        } else if (cid.startsWith("WS")) {
+            JsonObject envelope = new JsonObject();
+            envelope.addProperty("type", "external_api_response");
+            envelope.addProperty("correlation-id", cid);
+            envelope.add("data", root.get("data"));
+            UIWebsocketEndPoint.getInstance().broadcast(new Gson().toJson(envelope));
+        }
+    }
+}
+```
+
+Register once in `ApplicationMain.addCustomUISupport()` (or equivalent
+lifecycle hook):
+```java
+Cloud.getInstance().addPropertyChangeListener(new CloudDownloadListener());
+UIWebServiceProvider.getInstance().registerPostService("extApi", new ExternalApiService());
+UIWebServiceProvider.getInstance().openWebsocket("/socket", UIWebsocketEndPoint.getInstance());
+```
+
+### Same gotchas as C++
+
+- **Register the future BEFORE calling `uploadData`** in Pattern A — same
+  race window, same silent drop if you reverse the order.
+- **`uploadData(payload, 1)`** — second arg is importance, fixed at 1 by
+  convention.
+- **Pattern A 10 s ceiling** — don't extend beyond ~10 s; switch to
+  Pattern B for streaming or long-poll.
+- **D2D listener stub is intentional** — the Device2Device channel
+  exists but `handleMessage` is deliberately empty in the reference
+  projects. Don't copy Cloud dispatch into it unless you have a use case.
+
 ## DB Persistence
 
 Java H2 의 working DB 는 `./db/<name>.h2.mv.db` 에 두며 빌드 시 제외된다. 디바이스 영속 DB 는 `disk/<feature>/persist.h2.mv.db` 와 같이 `disk/<feature>/...` 하위에 위치하며 디바이스 측에서 런타임에 생성/유지한다 — 빌드 산출물(FIF) 에 포함되지 않는다. 앱이 의도적으로 동봉하는 시드 데이터(예: 초기 카탈로그 SQL/JSON) 는 `disk/seed/...` 하위에 두면 allowlist 정책으로 패키징되어 첫 부팅 시 디바이스로 복사된다.

--- a/skills/seamos-customui-client/SKILL.md
+++ b/skills/seamos-customui-client/SKILL.md
@@ -11,10 +11,11 @@ description: >
   web problem like "fetch 404", "WS not connecting", "CORS blocked", or
   "how do I read this stream in the browser". Covers `get_assigned_ports`
   port discovery, the four-frame WS protocol (publish / publish_ack /
-  topic / external_api_response), payload.PL parsing, and the
-  correlation-id cloud-proxy envelope for external HTTPS. Trigger
-  generously: under-triggering this skill produces code that compiles
-  fine and breaks on every real device.
+  topic / external_api_response), payload.PL parsing, the correlation-id
+  cloud-proxy envelope for external HTTPS, and the UI ⇄ backend envelope
+  key rename (endPoint → externalUrl, methodSelect → method, reqHeader →
+  header, reqBody → msg). Trigger generously: under-triggering this skill
+  produces code that compiles fine and breaks on every real device.
 ---
 
 # SeamOS CustomUI Client

--- a/skills/seamos-customui-client/references/cloud-proxy.md
+++ b/skills/seamos-customui-client/references/cloud-proxy.md
@@ -124,3 +124,65 @@ try {
   showError(err.message)
 }
 ```
+
+## How the backend dispatches the envelope (the other half)
+
+The UI-side envelope above is only half the story — the app's C++/Java side
+unwraps it, forwards through the Cloud plugin, and routes the response back.
+Knowing the contract here helps you debug "why isn't my response coming back"
+without reading the SDK source.
+
+### Key rename: UI envelope → proxy envelope
+
+The browser uses keys that read naturally to UI authors (`endPoint`,
+`methodSelect`). The Cloud proxy on the device speaks a different vocabulary
+(`externalUrl`, `method`). The app translates between them:
+
+| UI envelope (this skill) | Cloud proxy envelope (backend) |
+|--------------------------|--------------------------------|
+| `endPoint`               | `externalUrl`                  |
+| `methodSelect`           | `method`                       |
+| `reqHeader`              | `header`                       |
+| `reqBody`                | `msg`                          |
+| `correlation-id`         | `correlation-id` (passed through) |
+
+If the app receives an envelope without a `correlation-id`, it generates one
+of the form `WS{epoch_ms}` (or `HTTP{epoch_ms}` — see below).
+
+### Two backend dispatch patterns
+
+The official spec (https://docs.seamos.io/docs/4/5/4) defines two ways the
+app can wait for the response. The `correlation-id` **prefix** (`HTTP*` vs
+`WS*`) tells the response handler which path to take:
+
+| Pattern | UI entry point | correlation-id prefix | App-side wait | When to use |
+|---------|----------------|-----------------------|---------------|-------------|
+| **A. Sync HTTP proxy** | `POST /extApi` | `HTTP*` | `std::promise` + 10 s `wait_for` | Form submit, bulk fetch, UI expects synchronous return |
+| **B. Async WebSocket** | `ws://.../socket` | `WS*` | None — push back via WS | Real-time streams, multiple concurrent calls, long ops |
+
+This skill (browser-side) implements Pattern B. Pattern A is a parallel
+backend route the UI hits with plain `fetch('/extApi', ...)` instead of
+opening a WebSocket — useful when you want one round-trip without managing
+a WS pending-map.
+
+### Response envelope (incoming, again)
+
+The cloud returns `{ data, correlation-id }`. The app re-wraps it as the
+`external_api_response` frame documented above before publishing to the WS.
+The `data` field is the upstream response body, **already JSON-parsed by
+the app**.
+
+### When you suspect the backend, not the UI
+
+Symptoms that point at the backend, not your UI code:
+
+| Symptom | Likely backend cause |
+|---------|---------------------|
+| `external_api_response` never arrives, but `publish` works | Cloud channel not registered, or `CloudDownloadListener` not wired |
+| Response arrives but UI's pending-map orphans it | UI's `correlation-id` doesn't match what backend sent — backend may have generated its own |
+| 504 / Gateway Timeout | App used Pattern A and the upstream took >10 s; either retry or switch to Pattern B |
+
+Backend implementation (Cloud listener registration, prefix dispatch, the
+`uploadData(payload, 1)` call where `1` is the importance/priority and is
+conventionally fixed) lives in `seamos-app-framework` → External API Server
+Communication. Read that file when working on the app side.

--- a/skills/seamos-plugins/references/usage-patterns/cpp.md
+++ b/skills/seamos-plugins/references/usage-patterns/cpp.md
@@ -114,16 +114,35 @@ void MainController::run() {
 ## Platform Service Methods
 
 ```cpp
-platformService->uploadData(dataString);    // Cloud upload
-platformService->uploadFile(filePath);      // Cloud upload
-platformService->download(targetPath);      // Cloud download
-platformService->sendCommand(deviceId, command); // Device-to-Device
-platformService->sendFile(deviceId, filePath);   // Device-to-Device
-platformService->readQRCode();              // QR Scanner
-platformService->uploadAgriRouterFile(filePath); // AgriRouter
+// Cloud — note the (data, importance) signature on uploadData
+::nevonex::cloud::Cloud::getInstance()->uploadData(dataString, 1);
+//                                                             ↑
+// Second arg = importance (priority). Conventionally fixed at 1.
+// The Cloud channel uses it to bucket queued outbound traffic; vary it
+// only with a deliberate reason — most apps just pass 1.
+
+::nevonex::cloud::Cloud::getInstance()->uploadFile(filePath);
+::nevonex::cloud::Cloud::getInstance()->download(targetPath);
+
+// Device-to-Device
+platformService->sendCommand(deviceId, command);
+platformService->sendFile(deviceId, filePath);
+
+// QR Scanner
+platformService->readQRCode();
+
+// AgriRouter
+platformService->uploadAgriRouterFile(filePath);
 ```
 
 > **Note:** The C++ `PlatformServicesEnum` is currently empty in the reference implementation. Platform Service method patterns follow the same structure as Java but with pointer-based access.
+
+> **External API calls go through `Cloud::uploadData` — not a direct HTTP
+> client.** SeamOS apps never open TCP/HTTP sockets to external servers
+> directly; the platform forwards through the Cloud channel for auth/TLS/
+> audit. For the request/response correlation pattern (sync `/extApi` vs
+> async `/socket`, `correlation-id` prefix dispatch, `CloudDownloadListener`
+> wiring), see `seamos-app-framework` → External API Server Communication.
 
 ## Protected Region
 

--- a/skills/seamos-plugins/references/usage-patterns/java.md
+++ b/skills/seamos-plugins/references/usage-patterns/java.md
@@ -92,10 +92,15 @@ canAllynav.addPropertyChangeListener(event -> {
 Platform_Service uses a different pattern — method invocation instead of getter/setter.
 
 ```java
-// Cloud upload
-platformService.uploadData(dataString);
-platformService.uploadFile(filePath);
-platformService.download(targetPath);
+// Cloud — uploadData takes (data, importance)
+Cloud.getInstance().uploadData(dataString, 1);
+//                                          ↑
+// Second arg = importance (priority). Conventionally fixed at 1.
+// The Cloud channel uses it to bucket queued outbound traffic; vary it
+// only with a deliberate reason — most apps just pass 1.
+
+Cloud.getInstance().uploadFile(filePath);
+Cloud.getInstance().download(targetPath);
 
 // Device-to-Device
 platformService.sendCommand(deviceId, command);
@@ -107,6 +112,13 @@ platformService.readQRCode();
 // AgriRouter
 platformService.uploadAgriRouterFile(filePath);
 ```
+
+> **External API calls go through `Cloud.uploadData` — not a direct HTTP
+> client.** SeamOS apps never open external HTTP sockets directly; the
+> platform forwards through the Cloud channel for auth/TLS/audit. For the
+> request/response correlation pattern (sync `/extApi` vs async `/socket`,
+> `correlation-id` prefix dispatch, `CloudDownloadListener` wiring), see
+> `seamos-app-framework` → External API Server Communication.
 
 ## Key Interfaces
 


### PR DESCRIPTION
## Summary

공식 문서([docs.seamos.io/docs/4/5/4](https://docs.seamos.io/docs/4/5/4))와 reference 구현(`external_api_test`, `cpp_deploy_test_19`) 모두 존재하는 **외부 API 호출 패턴**이 스킬에 빠져 있던 갭을 메운다. SeamOS 앱은 외부 HTTPS 를 직접 호출하지 않고 **Cloud 플러그인 채널 + correlation-id 기반 응답 매칭** 으로 우회 — 이 규칙이 스킬에 없으면 Claude 가 `nlohmann::http_client` 같은 잘못된 코드를 만들어낸다.

코드 변경 없음 — 스킬 문서 + 트리거 키워드 + cross-reference 만.

## Changes

### seamos-app-framework — External API Server Communication 섹션 신설
- **`references/usage-patterns/cpp.md`** (+299 lines)
  - Pattern A: `POST /extApi` 동기 — `ExternalApiRequestManager` singleton + `std::promise`/`wait_for(10s)`
  - Pattern B: `ws://.../socket` 비동기 — `WebSocketEndPoint::onWebSocketMessage` → Cloud uploadData → `external_api_response` envelope broadcast
  - 단일 응답 핸들러: `CloudDownloadListener::handleMessage` 가 `correlation-id` prefix(`HTTP*` vs `WS*`) 로 두 패턴 분기
  - Gotcha 5 개: register-before-uploadData race, prefix 충돌, `uploadData(data, 1)` importance 인자 fixed, Pattern A 10 초 ceiling, D2D listener 빈 stub 의도적
- **`references/usage-patterns/java.md`** (+147 lines) — C++ ⇄ Java 타입 매핑 표 + Pattern A 풀 스켈레톤 (`CompletableFuture` + `ConcurrentHashMap`)
- **`SKILL.md`** — description 에 "external API server communication" 추가, 트리거 9 개 추가(`external API`, `외부 API`, `cloud proxy`, `uploadData`, `extApi`, `CloudDownloadListener`, `correlation-id`, `외부 서버 호출`, `백엔드 외부 호출`)

### seamos-customui-client — backend dispatch 가시화
- **`references/cloud-proxy.md`** (+62 lines) — UI ⇄ backend envelope key rename 표(`endPoint`→`externalUrl`, `methodSelect`→`method`, `reqHeader`→`header`, `reqBody`→`msg`), 두 패턴 요약, 백엔드 vs UI 의심 트러블슈팅 표
- **`SKILL.md`** — description 에 envelope key rename 명시(디버깅 첫 함정)

### seamos-plugins — Platform Service `uploadData` 시그니처 주석
- **`references/usage-patterns/cpp.md` / `java.md`** — `Cloud::uploadData(data, 1)` 두번째 인자 = importance(중요도, 보통 1 픽스) 주석 + 외부 API 호출은 직접 HTTP 클라이언트 금지 + `seamos-app-framework` 외부 API 섹션 cross-ref

### Version bump
- `0.7.5` → `0.7.6` (plugin.json, marketplace.json, README badge)
- CHANGELOG `[0.7.6]` entry

## Test plan

- [x] 모든 변경 파일 git diff 검토 (11 files, +592/-21)
- [x] cross-reference 양방향 일관성 (cloud-proxy.md → app-framework, app-framework → seamos-customui-client, seamos-plugins → app-framework)
- [x] `Cloud::uploadData(data, 1)` 사용 사례 5 군데 모두 importance 주석 일치
- [x] reference 구현 두 개(`external_api_test` 두 패턴 다, `cpp_deploy_test_19` WS-only) 모두 명시
- [ ] (수동) 다음 SeamOS 앱 생성 task 에서 외부 API 요구사항 포함 시 Claude 가 Pattern B 를 올바르게 생성하는지 verify