### PR TITLE
docs: v0.7.7 — Java External API SSOT corrected (agnote-core absorbed)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "seamos-everywhere",
       "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "author": {
         "name": "AGMO-Inc"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seamos-everywhere",
   "description": "SeamOS AI Native developer plugin — build, test, and deploy agricultural machinery apps using natural language through Claude Code",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "author": {
     "name": "AGMO-Inc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to **seamos-everywhere** are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [SemVer](https://semver.org/) (pre-1.0: minor bumps signal feature additions, patch bumps signal fixes).
 
+## [0.7.7] — 2026-05-08
+
+**Java External API SSOT 정정 — `agnote-core` 흡수.** v0.7.6 의 Java External API 섹션은 C++ 매핑에 의존한 *근사치* 였음. 사용자가 `~/Desktop/Backend/agnote-core` (실제 Java NEVONEX 앱) 를 가리키며 "이걸로 진짜 진행 가능한 상태인지" 물어 갭이 드러남. 그 코드를 SSOT 로 흡수해서 Java 측을 처음부터 검증된 패턴으로 갈아끼움.
+
+### Fixed — Java 패턴 정설화
+
+`skills/seamos-app-framework/references/usage-patterns/java.md` 의 External API 섹션 전면 재작성. 정정된 항목:
+
+- **`uploadData` 시그니처**: `(data, 1)` 2-arg 추측 → 실제 `(data, priority, ConnectionTypeEnum)` **3-arg, 반환 `String`**. `agnote-core` default priority 는 `2` (Medium), C++ 의 `1` 은 다른 프로젝트 컨벤션이었음.
+- **CloudDownloadListener 베이스 클래스**: `implements PropertyChangeListener` (잘못) → **`extends AbstractCloudDownloadListener implements ICloudDownloadListener, PropertyChangeListener`** + `handleContent`/`handleFile` override.
+- **PropertyChange 이벤트명**: `"download"` (잘못) → **`"CloudMessageReceived"`/`"CloudFileReceived"`**. v0.7.6 그대로 따라 짰다면 listener 가 등록은 되지만 영원히 발화 안 하는 silent bug.
+- **`PendingRequestRegistry` 패턴**: `Map<String, CompletableFuture<String>>` (sync 대기) → **`Map<String, String>`** (cid → type-string) + 60 s daemon evict. Java 가 sync 대기하지 않고 type-routed broadcast 하기 때문.
+- **응답 frame**: `external_api_response` (C++) → **`{"type":"EXT-{domain}", "data":...}`** (Java agnote). UI 측 dispatch 가 frame.type 으로 분기해야 함.
+- **broadcast 메서드명**: `broadcast(...)` → **`broadcastMessage(...)`** (`UIWebsocketEndPoint`).
+- **Listener 등록 hook**: `addCustomUISupport()` 안 → **`addListenersForDownload()`** 별도 lifecycle hook (`main()` 에서 `addCustomUISupport` 다음, `startProviders` 전 호출).
+- **`GracefulFeatureStop` 가드** 추가 — 셧다운 중 이벤트 처리 race 방지.
+- **`Cloud*Exception` 개별 catch** — `CloudBadRequestException`, `CloudUnAuthorizedException`, `CloudAccessDeniedException`, `CloudConnectionException`, `PlatformServiceException` 분리. 일반 `catch (Exception)` 는 auth 실패와 network 실패를 못 가림.
+- **Service 변종 분류 변경**: "Pattern A (sync `/extApi`) / Pattern B (async WS)" → **V1 (Cloud Upload ack-only) / V2 (Trigger + type-routed broadcast)**. agnote 에는 Pattern A 가 존재하지 않음 — 모두 `cloud-upload/{name}` REST 라우트가 `uploadData` 를 부르는 변종.
+- **UI envelope key**: agnote 의 UI 는 `endPoint`/`methodSelect` 별칭을 안 쓰고 처음부터 backend 키(`externalUrl`, `method`, `header`, `msg`)로 보냄. C++ reference 의 rename 은 프로젝트 의존 컨벤션으로 격하.
+- **`correlation-id` 형식**: `"HTTP{ms}"`/`"WS{ms}"` (C++) → **UUID v4** (Java agnote). Java 는 prefix 가 dispatch signal 이 아님 (registry 가 type-routing 담당).
+
+### Changed — Cross-language divergence surfaced
+
+- **`skills/seamos-app-framework/references/usage-patterns/cpp.md`** — External API 섹션 헤더에 "Java differs in several conventions — read `java.md`, don't translate from this section" 노트 추가.
+- **`skills/seamos-customui-client/references/cloud-proxy.md`** — Envelope key rename 표를 "Convention A vs B" 로 재구성. Response frame 표 추가 (`external_api_response` vs `EXT-{domain}`). UI dispatch 가 `frame.type` 분기해야 한다는 점 명시.
+- **`skills/seamos-plugins/references/usage-patterns/java.md`** — `Cloud.getInstance().uploadData(data, 1)` 2-arg 인용 → 3-arg `(data, priority, ConnectionTypeEnum.WIFI)` + 반환 `String` (cloud ack, not upstream body) 로 정정.
+- **`skills/seamos-app-framework/SKILL.md`** — 트리거 8개 추가 (`cloud-upload`, `클라우드 업로드`, `PendingRequestRegistry`, `CloudMessageReceived`, `CloudFileReceived`, `ConnectionTypeEnum`, `BaseRestService`, `AbstractCloudDownloadListener`, `EXT-frame`). Pattern Selection 의 External API 항목을 언어별로 분리 ("conventions differ by language — pick the right reference file"). 패턴 표의 External API 행에 "Java/C++ 컨벤션 다름" 경고 추가.
+
+### Why now (사용자 학습 동기)
+
+`agnote-core` 의 `CloudDownloadListener.java` / `PendingRequestRegistry.java` / `FuelPriceCloudUploadService.java` / `WeatherGetService.java` / `ApplicationMain.java` 와 그 프로젝트의 자체 `cloud-upload` 스킬 (service-template + registration-template) 까지 비교한 결과, v0.7.6 의 Java 섹션은 **컴파일은 되지만 listener 가 안 불리는 silent bug** 를 포함한 5~6 개 mismatch 가 있었음. 가장 치명적인 게 `"download"` vs `"CloudMessageReceived"` — 등록만 되고 영원히 발화 안 함. v0.7.7 은 그 갭을 닫는다.
+
+### Notes
+
+- 코드 변경 없음 — 스킬 문서/메타데이터만. 회귀 위험 없음.
+- C++ 섹션은 그대로 유지 (`cpp_deploy_test_19` 검증). 변경된 건 "Java 가 다르다" 는 cross-ref 만.
+- agnote-core 자체 cloud-upload 스킬은 외부 ref 로 링크하지 않음 — 그 스킬은 도메인별 service generator 라 seamos-everywhere 의 generic 스킬과 layer 가 다름.
+
 ## [0.7.6] — 2026-05-08
 
 **External API Server Communication 패턴 도큐먼트화.** 사용자가 SeamOS 앱(C++/Java)에서 외부 HTTPS API 를 호출하는 방법을 물었을 때, 스킬에는 — 공식 문서(https://docs.seamos.io/docs/4/5/4) 와 reference 구현(`external_api_test`, `cpp_deploy_test_19`) 모두 존재함에도 — 패턴이 전혀 들어 있지 않아 매번 raw 코드를 직접 읽고 재구성해야 했음. 이 갭을 메운다. 스킬 본체 코드 변경 없음 (문서 + 트리거 키워드 + cross-reference 만).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Claude Code plugin for the SeamOS AI Native developer ecosystem**
 
-[![Version](https://img.shields.io/badge/version-0.7.6-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
+[![Version](https://img.shields.io/badge/version-0.7.7-blue.svg)](https://github.com/AGMO-Inc/seamos-everywhere/releases)
 [![Skills](https://img.shields.io/badge/skills-12-orange.svg)](#skills)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 [![Org](https://img.shields.io/badge/org-AGMO--Inc-green.svg)](https://github.com/AGMO-Inc)

--- a/skills/seamos-app-framework/SKILL.md
+++ b/skills/seamos-app-framework/SKILL.md
@@ -11,7 +11,10 @@ description: >
   "lifecycle", "라이프사이클", "CRUD", "테이블", "table", "repository",
   "saveToDisk", "persistToDisk", "handleFeatureStart",
   "external API", "외부 API", "cloud proxy", "uploadData", "extApi",
-  "CloudDownloadListener", "correlation-id", "외부 서버 호출", "백엔드 외부 호출".
+  "CloudDownloadListener", "correlation-id", "외부 서버 호출", "백엔드 외부 호출",
+  "cloud-upload", "클라우드 업로드", "PendingRequestRegistry",
+  "CloudMessageReceived", "CloudFileReceived", "ConnectionTypeEnum",
+  "BaseRestService", "AbstractCloudDownloadListener", "EXT-frame".
 ---
 
 # SeamOS App Framework
@@ -33,7 +36,7 @@ Guide for developing SeamOS apps with REST APIs, WebSocket communication, databa
 | WebSocket | Jetty @WebSocket | WebSocketRouteFactory | Real-time communication |
 | DB Persistence | H2 + FCALFileProvider | SQLite + FileProvider | Data storage with container survival |
 | Feature Lifecycle | AbstractFeatureNotification | FeatureManagerListener + IgnitionStateListener | App start/stop hooks |
-| External API | `CompletableFuture` + Cloud + CloudDownloadListener | `std::promise` + Cloud + CloudDownloadListener | Outbound HTTPS to cloud / marketplace / 3rd-party |
+| External API | `BaseRestService` cloud-upload + `PendingRequestRegistry` (type→cid, 60s TTL) + `AbstractCloudDownloadListener` | `std::promise` + `/extApi` route + `CloudDownloadListener` | Outbound HTTPS to cloud / marketplace / 3rd-party. **Java and C++ conventions diverge — read the language file, don't translate across.** |
 
 ## Workflow
 
@@ -44,7 +47,9 @@ Determine which pattern the user needs:
 - **WebSocket** — Real-time bidirectional communication between app and client
 - **DB Persistence** — Structured data storage that survives NEVONEX container restarts
 - **Feature Lifecycle** — Hooks for app start, stop, and ignition state changes
-- **External API Server Communication** — Outbound calls from the app to non-local URLs (cloud APIs, marketplace, 3rd-party). Must route through the Cloud plugin's `uploadData` + `CloudDownloadListener` channel; direct HTTP sockets are not supported. Two sub-patterns: sync (`/extApi`, `HTTP*` correlation prefix, `std::promise`/`CompletableFuture` + 10 s wait) and async (`/socket`, `WS*` prefix, push back over WebSocket).
+- **External API Server Communication** — Outbound calls from the app to non-local URLs (cloud APIs, marketplace, 3rd-party). Must route through the Cloud plugin's `uploadData` + `CloudDownloadListener` channel; direct HTTP sockets are not supported. **Conventions differ by language — pick the right reference file**:
+  - **C++** (`cpp.md`, ref impl `cpp_deploy_test_19`): two patterns — sync `POST /extApi` (`HTTP*` prefix, `std::promise` + 10 s wait) and async `/socket` (`WS*` prefix, WS push). UI envelope renames keys (`endPoint`/`methodSelect`). Response frame: `external_api_response`.
+  - **Java** (`java.md`, ref impl `agnote-core`): `BaseRestService` cloud-upload routes (`cloud-upload/{name}`) — V1 (ack-only, registry-free) or V2 (`PendingRequestRegistry.register(cid, type)` + listener parses + `EXT-{domain}` broadcast). UI sends backend keys directly (no rename). `uploadData(data, priority, ConnectionTypeEnum)` 3-arg.
 
 ### Step 2: Language Detection
 

--- a/skills/seamos-app-framework/references/usage-patterns/cpp.md
+++ b/skills/seamos-app-framework/references/usage-patterns/cpp.md
@@ -108,8 +108,16 @@ customui::UIWebServiceProvider::getInstance()->registerWebsocketRoute("/socket",
 
 > Authoritative spec: https://docs.seamos.io/docs/4/5/4
 >
-> Reference implementations: `external_api_test` (full — both patterns) and
-> `cpp_deploy_test_19` (WebSocket-only variant).
+> C++ reference implementations: `external_api_test` (full — both
+> patterns) and `cpp_deploy_test_19` (WebSocket-only variant).
+>
+> **Java differs in several conventions** — different `uploadData`
+> signature (3-arg with `ConnectionTypeEnum`), no `/extApi` route in the
+> reference, response frame is `EXT-{domain}` instead of
+> `external_api_response`, registry holds type-strings not promises, and
+> the UI sends backend keys directly (no `endPoint→externalUrl` rename).
+> When generating Java, follow `java.md` § External API Server
+> Communication, not this section.
 
 ### Why the indirect path
 

--- a/skills/seamos-app-framework/references/usage-patterns/java.md
+++ b/skills/seamos-app-framework/references/usage-patterns/java.md
@@ -100,148 +100,364 @@ UIWebServiceProvider.getInstance().openWebsocket("/socket", UIWebsocketEndPoint.
 
 > Authoritative spec: https://docs.seamos.io/docs/4/5/4
 >
-> The reference implementations are C++ (`external_api_test`,
-> `cpp_deploy_test_19`). The architectural rules below apply identically to
-> Java — only the type names change. When generating Java code, mirror the
-> C++ patterns in `cpp.md` § External API Server Communication and adapt as
-> noted here.
+> Java reference implementation: **`agnote-core`** (`FuelPriceCloudUploadService`,
+> `WeatherGetService`, `CloudDownloadListener`, `PendingRequestRegistry`).
+> The conventions below are taken from real running code in that project —
+> they differ from the C++ reference (`cpp_deploy_test_19`) in several
+> places. Where the languages diverge, **trust this section for Java**;
+> see `cpp.md` for the C++ contract.
 
-### Same indirect-path rule
+### The indirect-path rule (same as C++)
 
 SeamOS Java apps **do not open external HTTP sockets directly**. Outbound
-traffic goes through the Cloud plugin; responses come back via the Cloud
-download listener. The platform owns auth, TLS, network policy, and audit
-logging.
+traffic goes through the Cloud plugin (`com.bosch.nevonex.cloud.impl.Cloud`),
+the platform forwards it, and responses come back via a
+`CloudDownloadListener`. The platform owns auth, TLS, network policy, and
+audit logging — call `HttpClient`/`URLConnection` from app code and you
+lose all of that.
 
-### Two patterns (same as C++)
+### How the C++ patterns map to Java
 
-| Pattern | UI entry | correlation-id prefix | App waits via | When to use |
-|---------|----------|-----------------------|---------------|-------------|
-| **A. Sync HTTP proxy** | `POST /extApi` | `HTTP*` | `CompletableFuture<String>` + `get(10, TimeUnit.SECONDS)` | UI expects synchronous return |
-| **B. Async WebSocket** | `ws://.../socket` | `WS*` | None — push back over WS | Real-time / concurrent / long ops |
+C++ docs split the work into "Pattern A (sync `POST /extApi`)" and
+"Pattern B (async WebSocket)". The Java reference (`agnote-core`) does
+**not** ship a `/extApi` route at all. Instead, every external call is a
+**plain REST endpoint that triggers a Cloud upload, then either returns
+immediately (ack-only) or has the response broadcast over the WebSocket
+when it lands**. Two variants emerge:
 
-### Java equivalents of the key types
+| Variant | Service shape | Registry use | UI receives via | When to use |
+|---------|---------------|--------------|-----------------|-------------|
+| **V1. Cloud Upload (ack-only)** | `{Name}CloudUploadService extends BaseRestService`, returns `{status, correlationId, response}` synchronously from `uploadData` | None — UI matches by `correlationId` later | Generic WS broadcast (whatever `CloudDownloadListener` does with the eventual response) | UI is happy with "request accepted, wait for it on the WS" semantics |
+| **V2. Trigger + type-routed broadcast** | `{Name}GetService extends BaseRestService`, `register(cid, "{type}")` then upload, returns `{"status":"success"}` immediately | `PendingRequestRegistry.register` / `consume` | `{"type":"EXT-{type}", "data":{parsed}}` frame on the WS | Response needs server-side parsing or domain routing before the UI sees it |
 
-| C++ | Java |
-|-----|------|
-| `ExternalApiRequestManager` (singleton, `std::map<id, std::promise>`) | Singleton with `ConcurrentHashMap<String, CompletableFuture<String>>` |
-| `std::promise<std::string>` / `wait_for` | `CompletableFuture<String>` + `get(10, TimeUnit.SECONDS)` |
-| `Json::Value` envelope + `Json::writeString` | `JsonObject` (Gson) + `gson.toJson(...)` |
-| `Cloud::getInstance()->uploadData(payload, 1)` | `Cloud.getInstance().uploadData(payloadString, 1)` — second arg is importance/priority, conventionally fixed at 1 |
-| `CloudDownloadListener::handleMessage` | `CloudDownloadListener#handleMessage(String)` registered via `Cloud.getInstance().addPropertyChangeListener(...)` |
-| `WebSocketEndPoint::onWebSocketMessage` | `@OnWebSocketMessage public void message(...)` on `UIWebsocketEndPoint` |
-| HTTP route `ExternalApiRoute` | `BaseRestService` subclass `ExternalApiService`, registered via `UIWebServiceProvider.getInstance().registerPostService("extApi", ...)` |
+A C++-style **synchronous** `/extApi` route (block the HTTP thread on a
+`CompletableFuture` for up to 10 s) is **possible** in Java but not
+present in any verified reference. If you need it, mirror the C++ Pattern A
+in `cpp.md` and use `CompletableFuture.get(10, TimeUnit.SECONDS)` —
+treat it as new ground, not a documented pattern.
 
-### Envelope key rename (identical to C++)
-
-```
-UI sends            App forwards
-─────────           ────────────
-endPoint        →   externalUrl
-methodSelect    →   method
-reqHeader       →   header
-reqBody         →   msg
-correlation-id  →   correlation-id (generate "HTTP{ms}" or "WS{ms}" if absent)
-```
-
-### Pattern A skeleton (Java)
+### `uploadData` signature (Java)
 
 ```java
-public class ExternalApiRequestManager {
-    private static final ExternalApiRequestManager INSTANCE = new ExternalApiRequestManager();
-    private final Map<String, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+String result = Cloud.getInstance()
+        .uploadData(dataString, priority, ConnectionTypeEnum.WIFI);
+//                              ↑          ↑
+//   priority 1=High / 2=Medium / 3=Low    ConnectionTypeEnum.{WIFI,SATELLITE}
+```
 
-    public static ExternalApiRequestManager getInstance() { return INSTANCE; }
+- **Three args, returns `String`** (cloud-side ack/result; not the upstream
+  HTTP body — that arrives later via `CloudDownloadListener`).
+- **Default priority in `agnote-core` is `2`** (Medium), not `1`. C++ docs
+  describe `1` as "fixed by convention" — that came from a different
+  project. Pick a deliberate value; `2` is the safe default.
+- `ConnectionTypeEnum` lives in `com.bosch.nevonex.common`.
+- Throws specific `Cloud{BadRequest,UnAuthorized,AccessDenied,Connection}Exception`
+  + `PlatformServiceException`. Catch each — error messages are the only
+  way to tell auth failures from network failures.
 
-    public void addPending(String cid, CompletableFuture<String> f) { pending.put(cid, f); }
-    public void notifyResponse(String cid, String body) {
-        CompletableFuture<String> f = pending.remove(cid);
-        if (f != null) f.complete(body);
-    }
-    public void remove(String cid) { pending.remove(cid); }
+### Outgoing envelope (the JSON inside `data`)
+
+```json
+{
+  "correlation-id": "550e8400-e29b-41d4-a716-446655440000",
+  "externalUrl":    "https://api.example.com/data",
+  "method":         "POST",
+  "header":         { "Content-Type": "application/json", "Authorization": "Bearer ..." },
+  "msg":            "<request body string>"
 }
 ```
 
-```java
-public class ExternalApiService extends BaseRestService {
-    @Override
-    public Object processService(Request request, Response response) {
-        JsonObject ui = parseBody(request);
+- `correlation-id`: **UUID v4** in `agnote-core` (`UUID.randomUUID().toString()`),
+  not `HTTP{ms}` / `WS{ms}` like C++. Don't rely on a prefix to dispatch
+  responses — Java uses the registry instead.
+- `header` is a JSON object. The service should default `Content-Type:
+  application/json` when caller omits it.
+- `msg` is typically a string but the reference keeps it as a `JsonElement`
+  so structured payloads pass through unchanged.
 
-        CompletableFuture<String> future = new CompletableFuture<>();
-        String cid = "HTTP" + System.currentTimeMillis();
-        ExternalApiRequestManager.getInstance().addPending(cid, future);
+> **UI envelope keys vs backend envelope keys** — `agnote-core`'s UI sends
+> the backend keys (`externalUrl`, `method`, `header`, `msg`) directly and
+> the service forwards them verbatim. The `endPoint`/`methodSelect`/
+> `reqHeader`/`reqBody` aliases described in `cpp.md` are a different
+> project's UI convention, not a Java-side requirement. If you start with
+> agnote, keep the keys aligned end-to-end.
+
+### Variant V1 — Cloud Upload service (ack-only)
+
+The whole service is just envelope-build + `uploadData`. The HTTP response
+hands the UI a `correlationId` it can match against the eventual WS frame.
+
+```java
+public class FuelPriceCloudUploadService extends BaseRestService {
+
+    @Override
+    protected Object processService(Request request, Response response) {
+        try {
+            JsonObject payload = parseBody(request);
+            if (payload == null) return errorResponse("Request body is empty");
+
+            // Validate externalUrl + method (POST/GET)
+            String externalUrl = requireString(payload, "externalUrl");
+            String method = requireString(payload, "method").toUpperCase();
+            if (!method.equals("POST") && !method.equals("GET")) {
+                return errorResponse("'method' must be POST or GET");
+            }
+
+            JsonObject header = payload.has("header") && payload.get("header").isJsonObject()
+                    ? payload.get("header").getAsJsonObject() : new JsonObject();
+            if (!header.has("Content-Type")) {
+                header.addProperty("Content-Type", "application/json");
+            }
+            JsonElement msg = payload.has("msg") ? payload.get("msg") : new JsonPrimitive("");
+
+            String correlationId = UUID.randomUUID().toString();
+            JsonObject envelope = new JsonObject();
+            envelope.addProperty("correlation-id", correlationId);
+            envelope.addProperty("externalUrl", externalUrl);
+            envelope.addProperty("method", method);
+            envelope.add("header", header);
+            envelope.add("msg", msg);
+
+            int priority = payload.has("priority") ? payload.get("priority").getAsInt() : 2;
+            ConnectionTypeEnum conn = payload.has("connectionType")
+                    ? ConnectionTypeEnum.get(payload.get("connectionType").getAsString())
+                    : ConnectionTypeEnum.WIFI;
+
+            String ack = Cloud.getInstance().uploadData(envelope.toString(), priority, conn);
+
+            JsonObject res = new JsonObject();
+            res.addProperty("status", "success");
+            res.addProperty("correlationId", correlationId);
+            res.addProperty("response", ack);
+            return res.toString();
+
+        } catch (CloudBadRequestException e)    { return errorResponse("Cloud bad request: " + e.getMessage()); }
+        catch (CloudUnAuthorizedException e)    { return errorResponse("Cloud unauthorized: " + e.getMessage()); }
+        catch (CloudAccessDeniedException e)    { return errorResponse("Cloud access denied: " + e.getMessage()); }
+        catch (CloudConnectionException e)      { return errorResponse("Cloud connection failed: " + e.getMessage()); }
+        catch (PlatformServiceException e)      { return errorResponse("Platform service error: " + e.getMessage()); }
+        catch (Exception e)                     { return errorResponse(e.getMessage()); }
+    }
+}
+```
+
+Registered with route prefix `cloud-upload/`:
+```java
+UIWebServiceProvider.getInstance()
+        .registerPostService("cloud-upload/fuel-price", fuelPriceCloudUploadService);
+```
+
+### Variant V2 — Trigger + type-routed broadcast
+
+When the listener needs to **parse / transform** the upstream response
+(e.g. weather: pick out today's max/min), tag the request with a `type` in
+`PendingRequestRegistry`. The listener consumes the type and broadcasts a
+domain frame.
+
+```java
+public class WeatherGetService extends BaseRestService {
+
+    private static final String BASE_URL =
+            "https://api.open-meteo.com/v1/forecast";
+
+    @Override
+    protected Object processService(Request request, Response response) {
+        String latitude  = requireQuery(request, "latitude");
+        String longitude = requireQuery(request, "longitude");
+
+        triggerExternalApiCall(latitude, longitude);
+
+        JsonObject result = new JsonObject();
+        result.addProperty("status", "success");
+        result.addProperty("message", "Weather request triggered");
+        return result.toString();
+    }
+
+    private void triggerExternalApiCall(String lat, String lon) {
+        String url = BASE_URL + "?latitude=" + lat + "&longitude=" + lon
+                + "&current=temperature_2m,weather_code"
+                + "&timezone=auto";
+
+        String cid = UUID.randomUUID().toString();
+        PendingRequestRegistry.getInstance().register(cid, "weather");
+        //                                              ↑
+        //  Tag = the type-routing key consumed by CloudDownloadListener.
 
         JsonObject envelope = new JsonObject();
         envelope.addProperty("correlation-id", cid);
-        envelope.addProperty("externalUrl", ui.get("endPoint").getAsString());
-        envelope.addProperty("method",      ui.get("methodSelect").getAsString());
-        envelope.add("header", ui.get("reqHeader"));
-        envelope.add("msg",    ui.get("reqBody"));
+        envelope.addProperty("externalUrl", url);
+        envelope.addProperty("method", "GET");
+        envelope.add("header", new JsonObject());
+        envelope.addProperty("msg", "");
 
-        Cloud.getInstance().uploadData(new Gson().toJson(envelope), 1);
-        //                                                          ↑
-        //  Importance (priority). Convention: fixed at 1.
+        Cloud.getInstance().uploadData(envelope.toString(), 2, ConnectionTypeEnum.WIFI);
+    }
+}
+```
+
+### `PendingRequestRegistry` — the agnote-core demux table
+
+A small singleton: **correlation-id → type-string**, with a 60 s TTL.
+*Not* a `CompletableFuture` map (that would block a thread; agnote
+listeners broadcast instead).
+
+```java
+public class PendingRequestRegistry {
+    private static final PendingRequestRegistry INSTANCE = new PendingRequestRegistry();
+    private static final long TTL_MS = 60_000;
+
+    private final ConcurrentHashMap<String, String> pending = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long>   timestamps = new ConcurrentHashMap<>();
+
+    private PendingRequestRegistry() {
+        ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "PendingRequestRegistry-cleaner");
+            t.setDaemon(true);  // don't pin JVM shutdown
+            return t;
+        });
+        cleaner.scheduleAtFixedRate(this::evictExpired, TTL_MS, TTL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    public static PendingRequestRegistry getInstance() { return INSTANCE; }
+
+    public void register(String correlationId, String type) {
+        pending.put(correlationId, type);
+        timestamps.put(correlationId, System.currentTimeMillis());
+    }
+
+    /** Returns the type, or null if unknown / expired. Removes the entry. */
+    public String consume(String correlationId) {
+        timestamps.remove(correlationId);
+        return pending.remove(correlationId);
+    }
+
+    private void evictExpired() {
+        long now = System.currentTimeMillis();
+        timestamps.entrySet().removeIf(e -> {
+            if (now - e.getValue() > TTL_MS) { pending.remove(e.getKey()); return true; }
+            return false;
+        });
+    }
+}
+```
+
+### `CloudDownloadListener` — single demux for all responses
+
+The listener is a NEVONEX-generated EMF object. Extend
+`AbstractCloudDownloadListener` and override `handleContent` /
+`handleFile`; the `propertyChange` glue routes platform events to those
+methods. Two non-obvious requirements:
+
+1. **Property names are `CloudMessageReceived` / `CloudFileReceived`** — not
+   `"download"`. Wrong name = listener registers but never fires.
+2. **Guard with `GracefulFeatureStop`** — the platform fires events even
+   during shutdown; processing them races against resource teardown and
+   throws spurious errors in the logs.
+
+```java
+public class CloudDownloadListener extends AbstractCloudDownloadListener
+        implements ICloudDownloadListener, PropertyChangeListener {
+
+    protected void handleFile(String filePath) {
+        // optional — Cloud-downloaded files land here
+    }
+
+    protected void handleContent(String message) {
+        if (GracefulFeatureStop.getInstance().isFeatureStopped()) return;
 
         try {
-            response.type("application/json");
-            return future.get(10, TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-            ExternalApiRequestManager.getInstance().remove(cid);
-            response.status(504);
-            return "{\"status\":504,\"msg\":\"Gateway Timeout: No response.\"}";
+            JsonObject json = JsonParser.parseString(message).getAsJsonObject();
+            String type = null;
+            if (json.has("correlation-id")) {
+                type = PendingRequestRegistry.getInstance()
+                        .consume(json.get("correlation-id").getAsString());
+            }
+
+            if ("weather".equals(type)) {
+                JsonObject parsed = parseWeatherResponse(json);
+                JsonObject frame = new JsonObject();
+                frame.addProperty("type", "EXT-weather");
+                frame.add("data", parsed);
+                UIWebsocketEndPoint.getInstance().broadcastMessage(frame.toString());
+            } else if (looksLikeFuelPriceResponse(message)) {
+                // V1 fallback: content-based routing for services that
+                // didn't register a type. Save to DB + broadcast.
+                JsonObject frame = new JsonObject();
+                frame.addProperty("type", "EXT-fuel");
+                frame.add("data", JsonParser.parseString(message));
+                UIWebsocketEndPoint.getInstance().broadcastMessage(frame.toString());
+            } else {
+                // Unknown response — pass through raw.
+                UIWebsocketEndPoint.getInstance().broadcastMessage(message);
+            }
         } catch (Exception e) {
-            response.status(500);
-            return errorResponse(e.getMessage());
+            FCALLogs.getInstance().log.error("broadcast failed: " + e.getMessage());
         }
     }
-}
-```
 
-### CloudDownloadListener dispatch (Java)
-
-```java
-public class CloudDownloadListener implements PropertyChangeListener {
     @Override
-    public void propertyChange(PropertyChangeEvent ev) {
-        if (!"download".equals(ev.getPropertyName())) return;
-        String content = ev.getNewValue().toString();
-        JsonObject root = JsonParser.parseString(content).getAsJsonObject();
-        if (!root.has("correlation-id")) return;
-        String cid = root.get("correlation-id").getAsString();
-
-        if (cid.startsWith("HTTP")) {
-            ExternalApiRequestManager.getInstance().notifyResponse(cid, content);
-        } else if (cid.startsWith("WS")) {
-            JsonObject envelope = new JsonObject();
-            envelope.addProperty("type", "external_api_response");
-            envelope.addProperty("correlation-id", cid);
-            envelope.add("data", root.get("data"));
-            UIWebsocketEndPoint.getInstance().broadcast(new Gson().toJson(envelope));
+    public void propertyChange(PropertyChangeEvent evt) {
+        switch (evt.getPropertyName()) {
+            case "CloudMessageReceived": handleContent((String) evt.getNewValue()); break;
+            case "CloudFileReceived":    handleFile((String) evt.getNewValue());    break;
+            default: /* ignore other Cloud events */
         }
     }
 }
 ```
 
-Register once in `ApplicationMain.addCustomUISupport()` (or equivalent
-lifecycle hook):
+### Listener registration
+
+`ApplicationMain` exposes a dedicated lifecycle hook for Cloud listeners:
+
 ```java
-Cloud.getInstance().addPropertyChangeListener(new CloudDownloadListener());
-UIWebServiceProvider.getInstance().registerPostService("extApi", new ExternalApiService());
-UIWebServiceProvider.getInstance().openWebsocket("/socket", UIWebsocketEndPoint.getInstance());
+public void addListenersForDownload() {
+    CloudDownloadListener listener = new CloudDownloadListener();
+    Cloud.getInstance().addPropertyChangeListener(listener);
+}
+
+// In ApplicationMain.main():
+sa.addCustomUISupport();         // REST + WS routes
+sa.addListenersForUserDefinedControls();
+sa.addListenersForDownload();    // ← THIS — easy to forget
+sa.startProviders();
 ```
 
-### Same gotchas as C++
+### Response frame on the WebSocket
 
-- **Register the future BEFORE calling `uploadData`** in Pattern A — same
-  race window, same silent drop if you reverse the order.
-- **`uploadData(payload, 1)`** — second arg is importance, fixed at 1 by
-  convention.
-- **Pattern A 10 s ceiling** — don't extend beyond ~10 s; switch to
-  Pattern B for streaming or long-poll.
-- **D2D listener stub is intentional** — the Device2Device channel
-  exists but `handleMessage` is deliberately empty in the reference
-  projects. Don't copy Cloud dispatch into it unless you have a use case.
+The browser receives:
+```json
+{ "type": "EXT-{domain}", "data": { /* parsed by CloudDownloadListener */ } }
+```
+
+This **differs from the C++ reference**, which broadcasts
+`{"type":"external_api_response","correlation-id":...,"data":...}`. If the
+UI is shared across both apps, branch on `type.startsWith("EXT-")` vs
+`type === "external_api_response"`. The agnote frame intentionally drops
+`correlation-id` because the broadcast is fan-out; UI matches by `type`.
+
+### Common gotchas (Java-specific)
+
+- **`addListenersForDownload()` must run after `initialize(...)` and
+  before `startProviders()`.** Off-order = `Cloud.getInstance()` is null
+  or events fire before the listener registers.
+- **PropertyChange names are case-sensitive strings.** `"cloudmessagereceived"`
+  fails silently. Match exactly: `"CloudMessageReceived"`,
+  `"CloudFileReceived"`.
+- **`PendingRequestRegistry` TTL is 60 s.** Slow upstreams blow past it
+  and the response arrives as untyped — listener falls through to the
+  passthrough branch, UI sees a raw JSON it can't parse. Either raise the
+  TTL with intent, or make the listener tolerate untyped responses
+  (agnote does the latter for fuel-price via content sniffing).
+- **`uploadData` returns the cloud-side ack, not the upstream body.** The
+  upstream body arrives later via the listener. Don't try to parse the
+  return value as your API response.
+- **Catch each `Cloud*Exception` separately.** Generic `catch (Exception)`
+  swallows the auth/network distinction. The reference services all break
+  these out into individual catches with distinct error messages.
+- **D2D listener stub is intentional** — `Device2DeviceDownloadListener`
+  exists but its `handleMessage` is deliberately empty. Don't copy Cloud
+  dispatch into it without a real D2D use case.
 
 ## DB Persistence
 

--- a/skills/seamos-customui-client/references/cloud-proxy.md
+++ b/skills/seamos-customui-client/references/cloud-proxy.md
@@ -132,22 +132,41 @@ unwraps it, forwards through the Cloud plugin, and routes the response back.
 Knowing the contract here helps you debug "why isn't my response coming back"
 without reading the SDK source.
 
-### Key rename: UI envelope → proxy envelope
+### Key rename: UI envelope → proxy envelope (project-dependent!)
 
-The browser uses keys that read naturally to UI authors (`endPoint`,
-`methodSelect`). The Cloud proxy on the device speaks a different vocabulary
-(`externalUrl`, `method`). The app translates between them:
+This is the part where two real projects disagree. **Check the backend
+service before settling on UI envelope keys.**
 
-| UI envelope (this skill) | Cloud proxy envelope (backend) |
-|--------------------------|--------------------------------|
-| `endPoint`               | `externalUrl`                  |
-| `methodSelect`           | `method`                       |
-| `reqHeader`              | `header`                       |
-| `reqBody`                | `msg`                          |
-| `correlation-id`         | `correlation-id` (passed through) |
+**Convention A — UI uses friendly aliases, app renames** (C++ reference
+`cpp_deploy_test_19`):
 
-If the app receives an envelope without a `correlation-id`, it generates one
-of the form `WS{epoch_ms}` (or `HTTP{epoch_ms}` — see below).
+| UI envelope        | Cloud proxy envelope |
+|--------------------|----------------------|
+| `endPoint`         | `externalUrl`        |
+| `methodSelect`     | `method`             |
+| `reqHeader`        | `header`             |
+| `reqBody`          | `msg`                |
+| `correlation-id`   | `correlation-id`     |
+
+**Convention B — UI sends backend keys directly, no rename** (Java reference
+`agnote-core`): UI just sends `externalUrl`, `method`, `header`, `msg`,
+`correlation-id`. The service forwards verbatim. This is simpler — start
+here unless you're targeting a backend that already speaks Convention A.
+
+If you don't know which the backend uses, grep its service class for
+`endPoint` (Convention A) or only `externalUrl` (Convention B). The
+"why isn't my response coming back" failure mode below is almost always
+"UI sent `endPoint` but backend reads `externalUrl`" or vice versa.
+
+If the app receives an envelope without a `correlation-id`, behaviour
+depends on the backend:
+- C++ reference: generates `WS{epoch_ms}` / `HTTP{epoch_ms}` and uses the
+  prefix to dispatch responses.
+- Java reference (`agnote-core`): expects the **service** to generate a
+  UUID v4 before calling `uploadData`. UI shouldn't omit it on the
+  WebSocket path either — agnote's listener uses `PendingRequestRegistry`
+  to demux by id, so a missing id falls into the untyped passthrough
+  branch and the UI may not recognise the frame.
 
 ### Two backend dispatch patterns
 
@@ -165,12 +184,26 @@ backend route the UI hits with plain `fetch('/extApi', ...)` instead of
 opening a WebSocket — useful when you want one round-trip without managing
 a WS pending-map.
 
-### Response envelope (incoming, again)
+### Response envelope (incoming) — frame shape varies by backend
 
-The cloud returns `{ data, correlation-id }`. The app re-wraps it as the
-`external_api_response` frame documented above before publishing to the WS.
-The `data` field is the upstream response body, **already JSON-parsed by
-the app**.
+The cloud returns `{ data, correlation-id }` to the app. **The app then
+re-wraps it before broadcasting**, and the wrapper differs across
+projects:
+
+| Backend reference | WS frame the UI sees |
+|-------------------|----------------------|
+| C++ (`cpp_deploy_test_19`) | `{"type":"external_api_response","correlation-id":"<id>","data":<body>}` |
+| Java (`agnote-core`) | `{"type":"EXT-<domain>","data":<body>}` — no `correlation-id`, type carries the routing info |
+
+UI dispatch should branch on `frame.type`:
+- `"external_api_response"` → look up `frame['correlation-id']` in the
+  pending-map (the snippet in the previous section).
+- `"EXT-…"` → match by `type` (e.g. `"EXT-weather"`, `"EXT-fuel"`) and
+  feed `frame.data` into the appropriate domain handler. There's no
+  per-request id to match against — the broadcast is fan-out.
+
+In both cases `data` is **already JSON-parsed by the app** — don't
+`JSON.parse` again.
 
 ### When you suspect the backend, not the UI
 

--- a/skills/seamos-plugins/references/usage-patterns/java.md
+++ b/skills/seamos-plugins/references/usage-patterns/java.md
@@ -92,12 +92,14 @@ canAllynav.addPropertyChangeListener(event -> {
 Platform_Service uses a different pattern — method invocation instead of getter/setter.
 
 ```java
-// Cloud — uploadData takes (data, importance)
-Cloud.getInstance().uploadData(dataString, 1);
-//                                          ↑
-// Second arg = importance (priority). Conventionally fixed at 1.
-// The Cloud channel uses it to bucket queued outbound traffic; vary it
-// only with a deliberate reason — most apps just pass 1.
+// Cloud — uploadData takes (data, priority, connectionType) and returns
+// a String ack from the cloud channel (NOT the upstream HTTP body).
+String ack = Cloud.getInstance()
+        .uploadData(dataString, 2, ConnectionTypeEnum.WIFI);
+//                              ↑   ↑
+//   priority: 1=High / 2=Medium (default in agnote-core) / 3=Low
+//                                  ↑
+//   ConnectionTypeEnum.{WIFI, SATELLITE} — defaults to WIFI
 
 Cloud.getInstance().uploadFile(filePath);
 Cloud.getInstance().download(targetPath);


### PR DESCRIPTION
## Summary

v0.7.6 의 Java External API 섹션은 C++ 매핑에 의존한 *근사치* 였고, **listener 가 등록은 되지만 영원히 발화 안 하는 silent bug** 까지 포함했음. `agnote-core` 의 검증된 Java 구현을 SSOT 로 흡수해서 `java.md` 전면 재작성.

- 코드 변경 없음 — 스킬 문서/메타데이터만 (9 files, +439/−137)
- C++ 섹션은 유지 (`cpp_deploy_test_19` 검증). 변경은 "Java 가 다르다" cross-ref 만.
- `cloud-proxy.md` 는 envelope key / 응답 frame 양쪽 컨벤션 명시 (Convention A: C++ rename / Convention B: Java agnote no-rename).

## What was wrong in v0.7.6

| 항목 | v0.7.6 (잘못) | agnote-core 실제 |
|---|---|---|
| `uploadData` 시그니처 | `(data, 1)` 2-arg | `(data, priority, ConnectionTypeEnum)` 3-arg, returns `String` |
| priority 기본값 | "1로 픽스" | 2 (Medium) |
| Listener 베이스 | `implements PropertyChangeListener` | `extends AbstractCloudDownloadListener implements ...` |
| **Property 이벤트명** | `"download"` | **`"CloudMessageReceived"`/`"CloudFileReceived"`** ← silent bug |
| Registry 패턴 | `Map<String, CompletableFuture>` | `Map<String, String>` (cid→type) + 60s TTL |
| 응답 frame | `external_api_response` | `EXT-{domain}` |
| Pattern A (`/extApi`) | Java 풀스켈레톤 | **agnote 에 존재 안 함** |
| Envelope key rename | `endPoint→externalUrl` 등 | UI 가 backend 키 그대로 사용 |
| `GracefulFeatureStop` 가드 | 누락 | 필수 |
| broadcast 메서드 | `broadcast(...)` | `broadcastMessage(...)` |
| 등록 hook | 미명시 | `addListenersForDownload()` 별도 |
| `correlation-id` 형식 | `HTTP{ms}`/`WS{ms}` | UUID v4 |

## What changed

### `skills/seamos-app-framework/references/usage-patterns/java.md`
- External API 섹션 전면 재작성. `agnote-core` reference impl 명시.
- 새 분류: **V1 (Cloud Upload ack-only)** = `FuelPriceCloudUploadService` / **V2 (Trigger + type-routed broadcast)** = `WeatherGetService`.
- `PendingRequestRegistry` 풀 코드 (60s daemon evict).
- `CloudDownloadListener` extends `AbstractCloudDownloadListener` + `handleContent`/`handleFile` override + `GracefulFeatureStop` 가드.
- `addListenersForDownload()` lifecycle hook + main() 호출 순서.
- 응답 frame `EXT-{domain}` + UI dispatch가 `frame.type` 분기 한다는 점.
- Java-specific gotcha 6개.

### `skills/seamos-app-framework/references/usage-patterns/cpp.md`
- 헤더에 "Java differs in several conventions — read `java.md`, don't translate from this section" 노트.

### `skills/seamos-customui-client/references/cloud-proxy.md`
- Envelope key 표를 **Convention A (C++ rename) vs Convention B (Java no-rename)** 로 재구성.
- Response frame 표 추가 (`external_api_response` vs `EXT-{domain}`).
- UI dispatch 가 `frame.type` 분기해야 한다는 점 명시.

### `skills/seamos-plugins/references/usage-patterns/java.md`
- `Cloud.getInstance().uploadData(data, 1)` → 3-arg `(data, priority, ConnectionTypeEnum.WIFI)` + 반환 `String` (cloud ack, not upstream body) 정정.

### `skills/seamos-app-framework/SKILL.md`
- 트리거 8개 추가 (`cloud-upload`, `클라우드 업로드`, `PendingRequestRegistry`, `CloudMessageReceived`, `CloudFileReceived`, `ConnectionTypeEnum`, `BaseRestService`, `AbstractCloudDownloadListener`, `EXT-frame`).
- Pattern Selection 의 External API 항목을 **언어별로 분리** + "conventions differ by language — pick the right reference file".
- 패턴 표의 External API 행에 "Java/C++ 컨벤션 다름" 경고.

### Version + CHANGELOG
- `plugin.json`, `marketplace.json`, README badge: 0.7.6 → 0.7.7
- CHANGELOG `[0.7.7]` entry

## Test plan

- [x] No code changes — skill docs only, no plugin install/setup/upload regression risk
- [x] Branch builds locally (no build step for docs)
- [x] `agnote-core` 의 실제 코드와 1:1 대조해서 작성
- [ ] (future) 다음 Java SeamOS 앱 만들 때 v0.7.7 스킬 그대로 적용해서 첫-시도-동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)