### PR TITLE
feat(skills): add vibe app agent playbook

### DIFF
--- a/shared-references/vibe-seamos-app-agent.md
+++ b/shared-references/vibe-seamos-app-agent.md
@@ -1,0 +1,108 @@
+# Vibe SeamOS App Agent Playbook
+
+Shared playbook for coordinating a complete SeamOS app build without turning
+the agent into a generic web/app generator.
+
+## Agent Stance
+
+- Act as a SeamOS app coordinator: route to the narrow skill that owns each
+  decision, then return to the flow map.
+- Keep the user in the product loop for app purpose, interface signals,
+  marketplace identity, and destructive rebuild/update decisions.
+- Prefer existing skills, scripts, and generated context over new snippets.
+- Keep outputs grounded in the user's SeamOS workspace, `.seamos-context.json`,
+  interface JSON, generated SDK app, and `seamos-assets/`.
+
+## Flow Map
+
+1. Bootstrap or locate workspace: `setup` if markers are missing, then
+   `create-project` for FSP + SDK/APP skeleton.
+2. Define interface: use `create-project` interface rules and `seamos-plugins`
+   for plugin/provider/signal selection.
+3. Implement app backend: use `seamos-app-framework` for REST, WebSocket,
+   lifecycle, DB persistence, and external API via Cloud plugin.
+4. Implement CustomUI: use `seamos-customui-ux` for ADS/operator UX and
+   `seamos-customui-client` for ports, REST base URL, WebSocket frames,
+   payload parsing, and cloud-proxy envelopes.
+5. Build: use `build-fif`; do not hand-package app artifacts.
+6. Publish: use `upload-app` for first marketplace release.
+7. Update: use `update-app` for a new version of an existing app.
+
+## New App Routing Chart
+
+| User signal | Primary skill | Required handoff |
+|---|---|---|
+| "Make a SeamOS app" with no project | `create-project` | Collect project name, language, interface JSON/source first |
+| Machine/CAN/GPS/IMU/GPIO/platform signal | `seamos-plugins` | Feed selected providers/signals into interface JSON and app code |
+| REST route, CRUD, DB, lifecycle, external API | `seamos-app-framework` | Keep CustomUI REST calls on assigned app port |
+| Screen, dashboard, controls, charts | `seamos-customui-ux` | Use ADS/operator rules before visual implementation |
+| Browser port, WS, topic stream, chart data, cloud API | `seamos-customui-client` | Use `get_assigned_ports`, app-port REST, four-frame WS protocol |
+| FIF/package | `build-fif` | Consume `.seamos-context.json` and output to `seamos-assets/builds/` |
+| First marketplace publish | `upload-app` | Validate `seamos-assets/` metadata, images, screenshots, FIF |
+| Existing marketplace app version | `update-app` | Select app, variant, arch, and FIF; do not use `config.json` |
+
+## Plugin Signals + CustomUI Chart Pattern
+
+- Start with the operator question, not a chart type: what value must be seen
+  while the machine is moving?
+- Select plugin/provider/signal with `seamos-plugins`; do not invent signal
+  names, units, directions, or payload fields.
+- Backend owns subscription, normalization, persistence, and REST/WS publishing.
+- CustomUI owns rendering, ADS layout, glanceability, and reconnect behavior.
+- Chart updates must tolerate sparse, delayed, or missing machine data; show
+  explicit stale/unknown states instead of fabricated values.
+
+## REST / DB Flow
+
+1. `seamos-app-framework` defines backend route, CORS behavior, persistence
+   path, lifecycle restore/save, and language-specific implementation.
+2. `seamos-customui-client` discovers the assigned port with relative
+   `get_assigned_ports`.
+3. UI REST calls target `http://${location.hostname}:${port}/path`, not the
+   UI gateway and not absolute same-origin paths.
+4. DB working files stay out of the FIF; only intentional seed data under
+   `disk/seed/` is packaged.
+
+## Marketplace Flow
+
+- Build with `build-fif` before upload/update.
+- First release uses `upload-app` and requires marketplace metadata, images,
+  screenshots, and at least one `.fif`.
+- Existing app versions use `update-app`; do not route updates through
+  `upload-app` unless the app is genuinely new.
+- Do not ask the user to hand-author `.mcp.json`; use `setup` or the helper
+  scripts documented by the upload/update skills.
+
+## STOP Conditions
+
+Stop and ask or remediate before continuing when:
+
+- Project name, language, or interface JSON source is ambiguous for a new app.
+- A requested signal/plugin cannot be found in the catalog/detail references.
+- A command would delete or overwrite hand-written app code.
+- Required workspace markers, Docker, marketplace auth, or FIF assets are
+  missing and the owning skill cannot self-remediate.
+- The user asks for direct external HTTP from the app backend; route through
+  the Cloud plugin pattern instead.
+- The user requests a generic web UI that ignores CustomUI port/proxy/ADS rules.
+
+## Anti-Generic Rules
+
+- Do not produce a generic React/Vite/SaaS app unless the SeamOS CustomUI
+  constraints are explicitly handled.
+- Do not hardcode ports, absolute asset paths, Google/CDN fonts, or external
+  browser fetches.
+- Do not bypass ADS for CustomUI controls, colors, spacing, or typography.
+- Do not invent REST/WS protocols; use the language-specific SeamOS patterns.
+- Do not duplicate long snippets from child skills in coordinator responses;
+  cite the owning skill and load its reference only when needed.
+
+## Token Safety
+
+- Load only the selected plugin detail file and grep very large detail files
+  such as `ISOPGN` or `Implement` for the requested signal.
+- Prefer catalog tables and flow summaries before opening language templates.
+- Keep the coordinator thin: summarize routing decisions, then delegate to
+  the specific skill's reference files.
+- Do not paste generated code or long snippets unless the user needs the code
+  changed in the workspace.

--- a/skills/build-fif/SKILL.md
+++ b/skills/build-fif/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[project-root] [--type java|cpp] [--arch aarch64|arm32|x86_64] [
 
 # FIF Build
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 Run the build script immediately. Do not explain — just execute.
 
 ```bash

--- a/skills/create-project/SKILL.md
+++ b/skills/create-project/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "--project-name <NAME> [--skip-sdk-app] [--codegen-type CPP|JAVA]
 
 # Create SeamOS Project (FSP + SDK/APP skeleton)
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 The first step in SeamOS app development. Generates an FSP project and — by default — the SDK / APP skeleton in a single invocation. Pass `--skip-sdk-app` to stop after FSP generation.
 
 UI type is fixed to `"Custom UI"`. Platforms: Windows (WSL2 / Git Bash), Linux, macOS (Apple Silicon included, requires Rosetta 2).

--- a/skills/seamos-app-framework/SKILL.md
+++ b/skills/seamos-app-framework/SKILL.md
@@ -19,6 +19,9 @@ description: >
 
 # SeamOS App Framework
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 Guide for developing SeamOS apps with REST APIs, WebSocket communication, database persistence, and feature lifecycle management.
 
 ## Quick Start

--- a/skills/seamos-customui-client/SKILL.md
+++ b/skills/seamos-customui-client/SKILL.md
@@ -22,6 +22,9 @@ description: >
 
 # SeamOS CustomUI Client
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 Browser-side companion to `seamos-app-framework`. The app's Java/C++ side
 opens a WebSocket at `/socket` (see that skill); this skill is everything the
 HTML/JS inside CustomUI needs to **find that socket, talk to it, and proxy

--- a/skills/seamos-customui-ux/SKILL.md
+++ b/skills/seamos-customui-ux/SKILL.md
@@ -29,6 +29,9 @@ description: >
 
 # SeamOS CustomUI UX
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 User-experience principles every SeamOS CustomUI must follow. The
 operating environment of a SeamOS app is **a screen on a moving
 machine, viewed by an operator whose other hand is on a control

--- a/skills/seamos-plugins/SKILL.md
+++ b/skills/seamos-plugins/SKILL.md
@@ -13,6 +13,9 @@ description: >
 
 # SEAMOS Plugin Reference
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 Guide for developing SeamOS apps using NEVONEX plugin Machine objects.
 
 ## Quick Start

--- a/skills/seamos-vibe-app-agent/SKILL.md
+++ b/skills/seamos-vibe-app-agent/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: seamos-vibe-app-agent
+description: >
+  Thin coordinator for end-to-end SeamOS app work. Use when the user asks to
+  make, build, publish, or iterate on a SeamOS app from a high-level product
+  idea, especially when the request spans project creation, plugin signals,
+  backend REST/DB/WebSocket work, CustomUI, FIF build, and marketplace upload
+  or update. Routes to existing SeamOS skills; does not replace them.
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# SeamOS Vibe App Agent
+
+Coordinate an end-to-end SeamOS app by routing to the owning skills. Keep this
+skill thin; do not duplicate long snippets or implementation templates from
+child skills.
+
+## Required Playbook
+
+Read the shared playbook first:
+
+[`shared-references/vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md)
+
+Use it to decide which existing skill owns the next step:
+
+- `create-project` for new FSP + SDK/APP skeletons and interface JSON setup
+- `seamos-plugins` for provider, Machine object, and signal selection
+- `seamos-app-framework` for REST, WebSocket, DB, lifecycle, and cloud-proxy backend patterns
+- `seamos-customui-ux` for ADS/operator UX rules
+- `seamos-customui-client` for CustomUI port discovery, REST base URL, WS frames, and browser cloud-proxy behavior
+- `build-fif` for packaging
+- `upload-app` for first marketplace publish
+- `update-app` for existing app version upload
+
+## Operating Rule
+
+At each step, name the owning skill, load only the references needed for that
+step, execute or edit through that skill's documented workflow, then return to
+the playbook flow map.

--- a/skills/update-app/SKILL.md
+++ b/skills/update-app/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[appId] [--feu-type FEU] [--arch ARCH] [--dry-run]"
 
 # Update App Version on SeamOS Marketplace
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 Upload a new version (.fif) of an existing app to the SeamOS marketplace. Unlike `upload-app` (which creates a brand-new app with full metadata and images), this skill only requires variant info and the app package file.
 
 This skill does NOT use config.json. All version info is collected interactively from the user, one question at a time.

--- a/skills/upload-app/SKILL.md
+++ b/skills/upload-app/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[--dry-run]"
 
 # Upload App to SeamOS Marketplace
 
+For end-to-end app coordination, follow the shared playbook:
+[`vibe-seamos-app-agent.md`](../../shared-references/vibe-seamos-app-agent.md).
+
 Upload a SeamOS app package (.fif) with metadata and assets to the SeamOS marketplace via REST API.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- Add a thin seamos-vibe-app-agent coordinator skill for end-to-end SeamOS app work
- Add a shared playbook for project creation, plugin signals, CustomUI, build, and marketplace routing
- Link existing SeamOS skills back to the shared playbook

## Verification
- git diff --check
- frontmatter/link sanity checks via worker
- integrated seamos-ide vitest/tsc checks before PR